### PR TITLE
Fix Analyzer permissions.

### DIFF
--- a/src/class/template.php
+++ b/src/class/template.php
@@ -73,7 +73,7 @@ class LOVD_Template
     {
         // Builds up the menu array, to be used in the full text/html header.
         // Can't be in the constructor, because that one is called before we have $_SESSION.
-        global $_AUTH;
+        global $_AUTH, $_SETT;
 
         if (defined('NOT_INSTALLED') || (ROOT_PATH == '../' && substr(lovd_getProjectFile(), 0, 9) == '/install/')) {
             // In install directory.
@@ -88,7 +88,7 @@ class LOVD_Template
                         'genes_' =>
                          array(
                              '/gene_panels' => array('menu_magnifying_glass.png', 'View all gene panels', 0),
-                             '/gene_panels?create' => array('plus.png', 'Create a new gene panel', LEVEL_SUBMITTER),
+                             '/gene_panels?create' => array('plus.png', 'Create a new gene panel', $_SETT['user_level_settings']['genepanels_create']),
                              'hr',
                              '/genes' => array('menu_magnifying_glass.png', 'View all genes', 0),
                              '/gene_statistics' => array('menu_magnifying_glass.png', 'View all gene statistics', 0),

--- a/src/download.php
+++ b/src/download.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-06-10
- * Modified    : 2019-07-25
+ * Modified    : 2019-10-10
  * For LOVD    : 3.0-22
  *
  * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
@@ -198,7 +198,7 @@ if (($_PE[1] == 'all' && (empty($_PE[2]) || in_array($_PE[2], array('gene', 'min
         $sHeader = 'Gene panel';
         $sFilter = 'genepanel';
         $ID = $_PE[2];
-        lovd_requireAuth(LEVEL_MANAGER);
+        lovd_requireAuth();
     } else {
         exit;
     }

--- a/src/gene_panels.php
+++ b/src/gene_panels.php
@@ -218,7 +218,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
             $aNavigation[CURRENT_PATH . '?history_full'] = array('menu_clock.png', 'View full history of genes in this gene panel', 1);
             $aNavigation['download/' . CURRENT_PATH]     = array('menu_save.png', 'Download this gene panel and its genes', 1);
         }
-        if ($_AUTH['level'] >= LEVEL_ADMIN) {
+        if ($_AUTH['level'] >= $_SETT['user_level_settings']['genepanels_delete']) {
             $aNavigation[CURRENT_PATH . '?delete'] = array('cross.png', 'Delete gene panel entry', 1);
         }
     }
@@ -551,7 +551,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'delete') {
     define('LOG_EVENT', 'GenePanelDelete');
 
     // Require admin clearance.
-    lovd_requireAUTH(LEVEL_ADMIN);
+    lovd_requireAUTH($_SETT['user_level_settings']['genepanels_delete']);
 
     require ROOT_PATH . 'class/object_gene_panels.php';
     $_DATA = new LOVD_GenePanel();

--- a/src/gene_panels.php
+++ b/src/gene_panels.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-03-01
- * Modified    : 2019-10-09
+ * Modified    : 2019-10-10
  * For LOVD    : 3.0-22
  *
  * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
@@ -205,15 +205,19 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
     $zData = $_DATA->viewEntry($nID);
 
     $aNavigation = array();
-    if ($_AUTH && $_AUTH['level'] >= LEVEL_ANALYZER) {
+    if ($_AUTH) {
         // Authorized user is logged in. Provide tools.
-        $aNavigation[CURRENT_PATH . '?edit']            = array('menu_edit.png', 'Edit gene panel information', 1);
-        $aNavigation[CURRENT_PATH . '?manage_genes']    = array('menu_plus.png', 'Manage gene panel\'s genes', 1);
-        $aNavigation[CURRENT_PATH . '?history']         = array('menu_clock.png', 'View differences between two dates', 1);
-        $aNavigation[CURRENT_PATH . '?history_full']    = array('menu_clock.png', 'View full history of genes in this gene panel', 1);
-        $aNavigation['download/' . CURRENT_PATH]        = array('menu_save.png', 'Download this gene panel and its genes', 1);
+        if ($_AUTH['level'] >= $_SETT['user_level_settings']['genepanels_edit']) {
+            $aNavigation[CURRENT_PATH . '?edit'] = array('menu_edit.png', 'Edit gene panel information', 1);
+        }
+        if ($_AUTH['level'] >= LEVEL_ANALYZER) {
+            $aNavigation[CURRENT_PATH . '?manage_genes'] = array('menu_plus.png', 'Manage gene panel\'s genes', 1);
+            $aNavigation[CURRENT_PATH . '?history']      = array('menu_clock.png', 'View differences between two dates', 1);
+            $aNavigation[CURRENT_PATH . '?history_full'] = array('menu_clock.png', 'View full history of genes in this gene panel', 1);
+            $aNavigation['download/' . CURRENT_PATH]     = array('menu_save.png', 'Download this gene panel and its genes', 1);
+        }
         if ($_AUTH['level'] >= LEVEL_ADMIN) {
-            $aNavigation[CURRENT_PATH . '?delete']      = array('cross.png', 'Delete gene panel entry', 1);
+            $aNavigation[CURRENT_PATH . '?delete'] = array('cross.png', 'Delete gene panel entry', 1);
         }
     }
     lovd_showJGNavigation($aNavigation, 'GenePanel');
@@ -374,7 +378,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'edit') {
     define('PAGE_TITLE', 'Edit gene panel entry #' . $nID);
     define('LOG_EVENT', 'GenePanelEdit');
 
-    lovd_requireAUTH(LEVEL_ANALYZER);
+    lovd_requireAUTH($_SETT['user_level_settings']['genepanels_edit']);
 
     require ROOT_PATH . 'class/object_gene_panels.php';
     $_DATA = new LOVD_GenePanel();

--- a/src/gene_panels.php
+++ b/src/gene_panels.php
@@ -1119,11 +1119,11 @@ if (PATH_COUNT == 3 && preg_match('/^[a-z][a-z0-9#@-]+$/i', rawurldecode($_PE[2]
 
     $aNavigation = array();
 
-    if ($_AUTH['level'] >= LEVEL_ANALYZER) {
+    if ($_AUTH['level'] >= $_SETT['user_level_settings']['genepanels_genes_edit']) {
         $aNavigation[CURRENT_PATH . '?edit'] = array('menu_edit.png', 'Edit gene information', 1);
     }
-    if ($_AUTH['level'] >= LEVEL_MANAGER) {
-        $aNavigation[CURRENT_PATH . '?delete']      = array('cross.png', 'Remove gene entry', 1);
+    if ($_AUTH['level'] >= $_SETT['user_level_settings']['genepanels_manage_genes']) {
+        $aNavigation[CURRENT_PATH . '?delete'] = array('cross.png', 'Remove gene entry', 1);
     }
 
     lovd_showJGNavigation($aNavigation, 'GenePanelGene');
@@ -1145,7 +1145,7 @@ if (PATH_COUNT == 3 && preg_match('/^[a-z][a-z0-9#@-]+$/i', rawurldecode($_PE[2]
     define('PAGE_TITLE', 'Edit gene ' . $sGeneID . ' in gene panel #' . $nGenePanelID);
     define('LOG_EVENT', 'GenePanelGeneEdit');
 
-    lovd_requireAUTH(LEVEL_ANALYZER);
+    lovd_requireAUTH($_SETT['user_level_settings']['genepanels_genes_edit']);
 
     require ROOT_PATH . 'class/object_gene_panel_genes.php';
     require ROOT_PATH . 'inc-lib-form.php';
@@ -1229,7 +1229,7 @@ if (PATH_COUNT == 3 && preg_match('/^[a-z][a-z0-9#@-]+$/i', rawurldecode($_PE[2]
     define('PAGE_TITLE', 'Remove gene ' . $sGeneID . ' from gene panel #' . $nGenePanelID);
     define('LOG_EVENT', 'GenePanelGeneDelete');
 
-    lovd_requireAUTH(LEVEL_MANAGER);
+    lovd_requireAUTH($_SETT['user_level_settings']['genepanels_manage_genes']);
 
     require ROOT_PATH . 'class/object_gene_panel_genes.php';
     require ROOT_PATH . 'inc-lib-form.php';

--- a/src/gene_panels.php
+++ b/src/gene_panels.php
@@ -167,7 +167,7 @@ if (PATH_COUNT == 1 && !ACTION) {
     // View all entries.
 
     // Submitters are allowed to download this panel...
-    if ($_AUTH['level'] >= LEVEL_SUBMITTER) {
+    if ($_AUTH) {
         define('FORMAT_ALLOW_TEXTPLAIN', true);
     }
 
@@ -213,11 +213,9 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
         if ($_AUTH['level'] >= $_SETT['user_level_settings']['genepanels_manage_genes']) {
             $aNavigation[CURRENT_PATH . '?manage_genes'] = array('menu_plus.png', 'Manage gene panel\'s genes', 1);
         }
-        if ($_AUTH['level'] >= LEVEL_ANALYZER) {
-            $aNavigation[CURRENT_PATH . '?history']      = array('menu_clock.png', 'View differences between two dates', 1);
-            $aNavigation[CURRENT_PATH . '?history_full'] = array('menu_clock.png', 'View full history of genes in this gene panel', 1);
-            $aNavigation['download/' . CURRENT_PATH]     = array('menu_save.png', 'Download this gene panel and its genes', 1);
-        }
+        $aNavigation[CURRENT_PATH . '?history']      = array('menu_clock.png', 'View differences between two dates', 1);
+        $aNavigation[CURRENT_PATH . '?history_full'] = array('menu_clock.png', 'View full history of genes in this gene panel', 1);
+        $aNavigation['download/' . CURRENT_PATH]     = array('menu_save.png', 'Download this gene panel and its genes', 1);
         if ($_AUTH['level'] >= $_SETT['user_level_settings']['genepanels_delete']) {
             $aNavigation[CURRENT_PATH . '?delete'] = array('cross.png', 'Delete gene panel entry', 1);
         }

--- a/src/gene_panels.php
+++ b/src/gene_panels.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-03-01
- * Modified    : 2019-08-19
- * For LOVD    : 3.0-21
+ * Modified    : 2019-10-09
+ * For LOVD    : 3.0-22
  *
  * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Anthony Marty <anthony.marty@unimelb.edu.au>
@@ -248,7 +248,7 @@ if (PATH_COUNT == 1 && ACTION == 'create') {
     define('PAGE_TITLE', 'Create a new gene panel entry');
     define('LOG_EVENT', 'GenePanelCreate');
 
-    lovd_requireAUTH(LEVEL_ANALYZER);
+    lovd_requireAUTH($_SETT['user_level_settings']['genepanels_create']);
 
     require ROOT_PATH . 'class/object_gene_panels.php';
     $_DATA = new LOVD_GenePanel();
@@ -262,7 +262,7 @@ if (PATH_COUNT == 1 && ACTION == 'create') {
             // Fields to be used.
             $aFields = array('name', 'description', 'type', 'remarks', 'created_by', 'created_date');
 
-            // If we are a manager then we can update the PMID mandatory field
+            // If we are a manager then we can update the PMID mandatory field.
             if ($_AUTH['level'] >= LEVEL_MANAGER) {
                 $aFields[] = 'pmid_mandatory';
             }

--- a/src/gene_panels.php
+++ b/src/gene_panels.php
@@ -210,8 +210,10 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
         if ($_AUTH['level'] >= $_SETT['user_level_settings']['genepanels_edit']) {
             $aNavigation[CURRENT_PATH . '?edit'] = array('menu_edit.png', 'Edit gene panel information', 1);
         }
-        if ($_AUTH['level'] >= LEVEL_ANALYZER) {
+        if ($_AUTH['level'] >= $_SETT['user_level_settings']['genepanels_manage_genes']) {
             $aNavigation[CURRENT_PATH . '?manage_genes'] = array('menu_plus.png', 'Manage gene panel\'s genes', 1);
+        }
+        if ($_AUTH['level'] >= LEVEL_ANALYZER) {
             $aNavigation[CURRENT_PATH . '?history']      = array('menu_clock.png', 'View differences between two dates', 1);
             $aNavigation[CURRENT_PATH . '?history_full'] = array('menu_clock.png', 'View full history of genes in this gene panel', 1);
             $aNavigation['download/' . CURRENT_PATH]     = array('menu_save.png', 'Download this gene panel and its genes', 1);
@@ -644,7 +646,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'manage_genes') {
     $nID = sprintf('%05d', $_PE[1]);
     define('LOG_EVENT', 'GenePanelManage');
 
-    lovd_requireAUTH(LEVEL_ANALYZER);
+    lovd_requireAUTH($_SETT['user_level_settings']['genepanels_manage_genes']);
     $bRemovableGenes = ($_AUTH['level'] >= LEVEL_MANAGER);
 
     $zData = $_DB->query('SELECT * FROM ' . TABLE_GENE_PANELS . ' WHERE id = ?', array($nID))->fetchAssoc();

--- a/src/gene_panels.php
+++ b/src/gene_panels.php
@@ -647,7 +647,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'manage_genes') {
     define('LOG_EVENT', 'GenePanelManage');
 
     lovd_requireAUTH($_SETT['user_level_settings']['genepanels_manage_genes']);
-    $bRemovableGenes = ($_AUTH['level'] >= LEVEL_MANAGER);
+    $bRemovableGenes = ($_AUTH['level'] >= $_SETT['user_level_settings']['genepanels_genes_delete']);
 
     $zData = $_DB->query('SELECT * FROM ' . TABLE_GENE_PANELS . ' WHERE id = ?', array($nID))->fetchAssoc();
     if (!$zData) {
@@ -815,7 +815,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'manage_genes') {
             }
 
             // Now delete what was no longer selected.
-            if ($aGenesCurrentlyAssociated && $_AUTH['level'] >= LEVEL_MANAGER) {
+            if ($aGenesCurrentlyAssociated && $bRemovableGenes) {
                 // When not using deleteEntry(), we could simply run one query for all genes that were dropped.
                 // However, for that we'd need to duplicate code handling the revision history.
                 // So we're going to keep the code simple, in expense of some speed on large deletions.
@@ -983,7 +983,8 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'manage_genes') {
 
     lovd_showInfoTable('All genes below have been selected for this gene panel.<BR>' .
         (!$bRemovableGenes?
-            'Only higher level users can also remove genes from this gene panel. If you believe a certain gene should be removed, please ask a Manager to do so.' :
+            'Only higher level users can also remove genes from this gene panel. If you believe a certain gene should be removed, please ask a ' .
+            $_SETT['user_levels'][$_SETT['user_level_settings']['genepanels_genes_delete']] . ' to do so.' :
             'To remove a gene from this list, click the red cross on the far right of the line.'), 'information', 950);
 
     $aInheritances =
@@ -1122,7 +1123,7 @@ if (PATH_COUNT == 3 && preg_match('/^[a-z][a-z0-9#@-]+$/i', rawurldecode($_PE[2]
     if ($_AUTH['level'] >= $_SETT['user_level_settings']['genepanels_genes_edit']) {
         $aNavigation[CURRENT_PATH . '?edit'] = array('menu_edit.png', 'Edit gene information', 1);
     }
-    if ($_AUTH['level'] >= $_SETT['user_level_settings']['genepanels_manage_genes']) {
+    if ($_AUTH['level'] >= $_SETT['user_level_settings']['genepanels_genes_delete']) {
         $aNavigation[CURRENT_PATH . '?delete'] = array('cross.png', 'Remove gene entry', 1);
     }
 
@@ -1229,7 +1230,7 @@ if (PATH_COUNT == 3 && preg_match('/^[a-z][a-z0-9#@-]+$/i', rawurldecode($_PE[2]
     define('PAGE_TITLE', 'Remove gene ' . $sGeneID . ' from gene panel #' . $nGenePanelID);
     define('LOG_EVENT', 'GenePanelGeneDelete');
 
-    lovd_requireAUTH($_SETT['user_level_settings']['genepanels_manage_genes']);
+    lovd_requireAUTH($_SETT['user_level_settings']['genepanels_genes_delete']);
 
     require ROOT_PATH . 'class/object_gene_panel_genes.php';
     require ROOT_PATH . 'inc-lib-form.php';

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -172,6 +172,7 @@ $_SETT = array(
                     'genepanels_create' => LEVEL_MANAGER,
                     'genepanels_delete' => LEVEL_ADMIN,
                     'genepanels_edit' => LEVEL_MANAGER,
+                    'genepanels_genes_delete' => LEVEL_MANAGER,
                     'genepanels_genes_edit' => LEVEL_ANALYZER,
                     'genepanels_manage_genes' => LEVEL_MANAGER,
                     // The see_nonpublic_data setting currently also defines the visibility

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -170,6 +170,7 @@ $_SETT = array(
                     'delete_individual' => (LOVD_plus? LEVEL_ADMIN : LEVEL_CURATOR),
                     'delete_variant' => (LOVD_plus? LEVEL_ADMIN : LEVEL_CURATOR),
                     'genepanels_create' => LEVEL_MANAGER,
+                    'genepanels_delete' => LEVEL_ADMIN,
                     'genepanels_edit' => LEVEL_MANAGER,
                     'genepanels_genes_edit' => LEVEL_ANALYZER,
                     'genepanels_manage_genes' => LEVEL_MANAGER,

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2019-10-09
+ * Modified    : 2019-10-10
  * For LOVD    : 3.0-22
  *
  * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
@@ -170,6 +170,7 @@ $_SETT = array(
                     'delete_individual' => (LOVD_plus? LEVEL_ADMIN : LEVEL_CURATOR),
                     'delete_variant' => (LOVD_plus? LEVEL_ADMIN : LEVEL_CURATOR),
                     'genepanels_create' => LEVEL_MANAGER,
+                    'genepanels_edit' => LEVEL_MANAGER,
                     // The see_nonpublic_data setting currently also defines the visibility
                     //  of the status, created* and edited* fields.
                     'see_nonpublic_data' => (LOVD_plus? LEVEL_SUBMITTER : LEVEL_COLLABORATOR),

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -171,6 +171,7 @@ $_SETT = array(
                     'delete_variant' => (LOVD_plus? LEVEL_ADMIN : LEVEL_CURATOR),
                     'genepanels_create' => LEVEL_MANAGER,
                     'genepanels_edit' => LEVEL_MANAGER,
+                    'genepanels_genes_edit' => LEVEL_ANALYZER,
                     'genepanels_manage_genes' => LEVEL_MANAGER,
                     // The see_nonpublic_data setting currently also defines the visibility
                     //  of the status, created* and edited* fields.

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -171,6 +171,7 @@ $_SETT = array(
                     'delete_variant' => (LOVD_plus? LEVEL_ADMIN : LEVEL_CURATOR),
                     'genepanels_create' => LEVEL_MANAGER,
                     'genepanels_edit' => LEVEL_MANAGER,
+                    'genepanels_manage_genes' => LEVEL_MANAGER,
                     // The see_nonpublic_data setting currently also defines the visibility
                     //  of the status, created* and edited* fields.
                     'see_nonpublic_data' => (LOVD_plus? LEVEL_SUBMITTER : LEVEL_COLLABORATOR),

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2019-10-01
+ * Modified    : 2019-10-09
  * For LOVD    : 3.0-22
  *
  * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
@@ -166,8 +166,10 @@ $_SETT = array(
                 array(
                     // Checking for LEVEL_COLLABORATOR assumes lovd_isAuthorized()
                     // has already been called for gene-specific overviews.
+                    // FIXME: Many more will follow. Better use 'object_action' naming convention.
                     'delete_individual' => (LOVD_plus? LEVEL_ADMIN : LEVEL_CURATOR),
                     'delete_variant' => (LOVD_plus? LEVEL_ADMIN : LEVEL_CURATOR),
+                    'genepanels_create' => LEVEL_MANAGER,
                     // The see_nonpublic_data setting currently also defines the visibility
                     //  of the status, created* and edited* fields.
                     'see_nonpublic_data' => (LOVD_plus? LEVEL_SUBMITTER : LEVEL_COLLABORATOR),


### PR DESCRIPTION
Fix Analyzer permissions.
- To create a gene panel, now the user level Manager is required, instead of Analyzer.
- To edit a gene panel, now the user level Manager is required, instead of Analyzer.
- To manage a gene panel's genes, now the user level Manager is required, instead of Analyzer.
- Created settings in `$_SETT['user_level_settings']` for all of this, so that other Instances can easily overwrite this setting.
- Changed naming convention of `$_SETT['user_level_settings']` array.

Also:
- Applied `$_SETT['user_level_settings']` setting for editing a gene panel's gene.
- Created a `$_SETT['user_level_settings']` setting for deleting a gene panel's gene.
- Created a `$_SETT['user_level_settings']` setting for deleting a gene panel.
- Allow gene panel history views and downloads for all authorized users.