### PR TITLE
Fixed some small issues.

### DIFF
--- a/src/class/object_custom_viewlists.plus.php
+++ b/src/class/object_custom_viewlists.plus.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2013-11-07
- * Modified    : 2019-10-09
+ * Modified    : 2019-10-16
  * For LOVD    : 3.0-22
  *
  * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
@@ -415,7 +415,7 @@ class LOVD_CustomViewListPLUS extends LOVD_CustomViewList
                                         'view' => array('Class.', 60),
                                         'db'   => (!in_array('AnalysisRunResults', $aObjects)?
                                             array('eg.name', 'ASC', true) :
-                                            array('CONCAT(REPLACE(IFNULL(sa.effectid, 5), 0, 5), REPLACE(RIGHT(IFNULL(vog.effectid, 5), 1), 0, 5), REPLACE(LEFT(IFNULL(vog.effectid, 5), 1), 0, 5))', 'DESC', true)),
+                                            array('CONCAT(REPLACE(IFNULL(sa.effectid, 5), 0, 5), REPLACE(RIGHT(IFNULL(vog.effectid, 5), 1), 0, 5), REPLACE(LEFT(IFNULL(vog.effectid, 5), 1), 0, 5), eg.name)', 'DESC', 'TEXT')),
                                         'legend' => array(
                                             strip_tags(str_replace(array('<TR>', '</TD> <TD>'), array("\n", '      '), preg_replace('/\s+/', ' ', strip_tags($sEffectLegend, '<tr><td>')))),
                                             $sEffectLegend)),

--- a/src/class/object_users.php
+++ b/src/class/object_users.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2019-02-13
+ * Modified    : 2019-10-16
  * For LOVD    : 3.0-22
  *
  * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
@@ -375,7 +375,7 @@ class LOVD_User extends LOVD_Object
                         'hr',
                         array('Country', '', 'select', 'countryid', 1, $aCountryList, true, false, false),
                         array('City', 'Please enter your city, even if it\'s included in your postal address, for sorting purposes.', 'text', 'city', 30),
-                        array('Reference (optional)', 'Your submissions will contain a reference to you in the format "Country:City" by default. You may change this to your preferred reference here.', 'text', 'reference', 30),
+         'reference' => array('Reference (optional)', 'Your submissions will contain a reference to you in the format "Country:City" by default. You may change this to your preferred reference here.', 'text', 'reference', 30),
                         'hr',
                         'skip',
                         array('', '', 'print', '<B>Security</B>'),
@@ -426,8 +426,12 @@ class LOVD_User extends LOVD_Object
                 unset($this->aFormData['change_self']);
             }
         }
-        if (LOVD_plus && isset($this->aFormData['level'])) {
-            $this->aFormData['level'][1] = ($_AUTH['level'] != LEVEL_ADMIN? '' : '<B>Managers</B> basically have the same rights as you, but can\'t uninstall LOVD nor can they create or edit other Manager accounts.<BR>') . '<B>Analyzers</B> can analyze individuals that are not analyzed yet by somebody else, but can not send variants for confirmation.<BR><B>Read-only</B> users can only see existing data in LOVD+, but can not start or edit any analyses or data.';
+        if (LOVD_plus) {
+            if (isset($this->aFormData['level'])) {
+                $this->aFormData['level'][1] = ($_AUTH['level'] != LEVEL_ADMIN? '' : '<B>Managers</B> basically have the same rights as you, but can\'t uninstall LOVD nor can they create or edit other Manager accounts.<BR>') . '<B>Analyzers</B> can analyze individuals that are not analyzed yet by somebody else, but can not send variants for confirmation.<BR><B>Read-only</B> users can only see existing data in LOVD+, but can not start or edit any analyses or data.';
+            }
+            // Unused, don't let it confuse users.
+            unset($this->aFormData['reference']);
         }
         return parent::getForm();
     }

--- a/src/class/objects.php
+++ b/src/class/objects.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2019-10-09
+ * Modified    : 2019-10-16
  * For LOVD    : 3.0-22
  *
  * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
@@ -2334,10 +2334,12 @@ class LOVD_Object
         }
 
         $sSQLOrderBy = $this->aColumnsViewList[$aOrder[0]]['db'][0] . ' ' . $aOrder[1];
-        if (preg_match('/AS\s+`?' . preg_quote($aOrder[0], '/') . '`?\b/i', $this->aSQLViewList['SELECT'])) {
+        if (preg_match('/^\w\./', $this->aColumnsViewList[$aOrder[0]]['db'][0]) // Only for normal columns.
+            && preg_match('/AS\s+`?' . preg_quote($aOrder[0], '/') . '`?\b/i', $this->aSQLViewList['SELECT'])) {
             // Current field name is present as an alias in SELECT clause, use
             // this instead in the ORDER BY clause. (needed for aggregated
             // fields)
+            // But we should *only* do this when the db field was just a given column ("table.column").
             $sSQLOrderBy = '`' . trim($aOrder[0], '`') . '` ' . $aOrder[1];
         }
 


### PR DESCRIPTION
Fixed some small issues.
- Fixed bug; Sorting on variant effect no longer worked.
  - The update to LOVD 3.0-20 broke this feature (while trying to solve https://github.com/LOVDnl/LOVD3/issues/291 / https://github.com/LOVDnl/LOVD3/pull/297).
  - LOVD 3.0-20 overwrites the sort field to using the column's SQL alias when it finds one in the `SELECT` statement. However, in this case the variant effect field shows something else then it should sort on, breaking the sorting order.
  - Overwriting of the sort field now only happens when normal column names are passed.
- Fixed bug; Searching on variant effect in the Analysis results VL didn't work anymore.
  - Because we defined a sort alias, searching also happens on this code. However, it doesn't contain the text that was displayed.
  - To fix this, used `CONCAT()` to add the `eg.name` field, which contains the variant's effect.
  - This doesn't allow searching on the SAR's effect, but it's better than nothing.
- Fixed bug; LOVD+ never got the `auth_token` and `auth_token_expires` columns from LOVD3 because the update was missed.
  - This caused notices in the user detailed view, and of course also a broken token generation and broken submission API.
- Removed reference field from the Users form, as it is not used and will just confuse users.