### PR TITLE
Added feature to manually select a file to be imported as a new screening.

### DIFF
--- a/src/ajax/import_scheduler.php
+++ b/src/ajax/import_scheduler.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2017-11-16
- * Modified    : 2019-10-28
+ * Modified    : 2019-10-29
  * For LOVD    : 3.0-22
  *
  * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
@@ -33,7 +33,7 @@ require ROOT_PATH . 'inc-init.php';
 header('Content-type: text/javascript; charset=UTF-8');
 
 // Check for basic format.
-if (PATH_COUNT != 3 || !in_array(ACTION, array('reschedule', 'set_priority', 'unschedule', 'view'))) {
+if (PATH_COUNT != 3 || !in_array(ACTION, array('new_screening', 'reschedule', 'set_priority', 'unschedule', 'view'))) {
     die('alert("Error while sending data.");');
 }
 
@@ -80,6 +80,7 @@ $sFormSetPriority    = '<FORM id=\'import_scheduler_set_priority_form\'><INPUT t
             array_keys($_SETT['import_priorities']), $_SETT['import_priorities'])
     ) . '</SELECT></FORM>';
 $sFormReschedule     = '<FORM id=\'import_scheduler_reschedule_form\'><INPUT type=\'hidden\' name=\'csrf_token\' value=\'{{CSRF_TOKEN}}\'>Are you sure you want to clear all errors and reschedule this file?</FORM>';
+$sFormNewScreening   = '<FORM id=\'import_scheduler_new_screening_form\'><INPUT type=\'hidden\' name=\'csrf_token\' value=\'{{CSRF_TOKEN}}\'>This will remove the Individual entry from the import file, and configure the file to be imported as a new Screening of this Individual.<BR><BR>This action can not be undone.<BR><BR>Are you sure you want to edit this file?</FORM>';
 $sMessageIntro       = 'Please choose from the actions below.<BR>';
 $sMessageUnschedule  = 'You can unschedule this file, which will remove it from the list of files to import. You can do this by clicking &quot;Unschedule file&quot; below.<BR>';
 $sMessageSetPriority = 'You can set the priority with which this file will be imported by clicking &quot;Set priority&quot; below.<BR>';
@@ -102,6 +103,7 @@ var oButtonClose           = {"Close":function () { $(this).dialog("close"); }};
 var oButtonFormUnschedule  = {"Yes, unschedule":function () { $.post("' . CURRENT_PATH . '?unschedule", $("#import_scheduler_unschedule_form").serialize()); }};
 var oButtonFormSetPriority = {"Set priority":function () { $.post("' . CURRENT_PATH . '?set_priority", $("#import_scheduler_set_priority_form").serialize()); }};
 var oButtonFormReschedule  = {"Yes, reschedule file":function () { $.post("' . CURRENT_PATH . '?reschedule", $("#import_scheduler_reschedule_form").serialize()); }};
+var oButtonFormNewScreening = {"Yes, edit this file":function () { $.post("' . CURRENT_PATH . '?new_screening", $("#import_scheduler_new_screening_form").serialize()); }};
 
 
 ');
@@ -258,7 +260,162 @@ if (ACTION == 'reschedule' && POST) {
     setTimeout(\'window.location.href = window.location.href;\', 1000);
     
     // Select the right buttons.
-    $("#import_scheduler_dialog").dialog({buttons: oButtonBack}); 
+    $("#import_scheduler_dialog").dialog({buttons: oButtonClose}); 
+    ');
+    exit;
+}
+
+
+
+
+
+if (ACTION == 'new_screening') {
+    // Common code for GET and POST.
+
+    if ($bFileLost) {
+        die('alert("Error: File not found.\n");');
+    }
+
+    if (!$bErrorLabID) {
+        die('alert("Error: File did not fail to import, so why would I edit it?\n");');
+    }
+
+    // Check if the file is edited already.
+    // Read the first 5K of the Total file, which should contain the meta data.
+    // file() can't restrict the reading to a certain limit, so we need a step in between.
+    $sMetaData = file_get_contents($_INI['paths']['data_files'] . '/' . $sFile, false, null, 0, 5000);
+    if (!$sMetaData) {
+        die('alert("Error: Could not read file.\n");');
+    }
+    $aMetaData = preg_split('/\r?\n/', $sMetaData);
+    $aParsed = $_ADAPTER->readMetadata($aMetaData);
+    if (empty($aParsed['Individuals']) || empty($aParsed['Screenings'])) {
+        // Not all data was found. Already edited?
+        if (!empty($aParsed['Screenings']) && !empty($aParsed['Genes']) && !empty($aParsed['Transcripts'])) {
+            // Very basic check, but at least it's a better error message.
+            die('alert("Error: It seems that the file has already been edited to be imported as a new Screening.\n");');
+        } else {
+            die('alert("Error: Could not parse the given file. I will not try and edit it.\n");');
+        }
+    }
+}
+
+
+
+
+
+if (ACTION == 'new_screening' && GET) {
+    // Show form for setting the priority.
+    // We do this in two steps, to prevent CSRF.
+
+    $_SESSION['csrf_tokens']['import_scheduler_new_screening'] = md5(uniqid());
+    $sFormNewScreening = str_replace('{{CSRF_TOKEN}}', $_SESSION['csrf_tokens']['import_scheduler_new_screening'], $sFormNewScreening);
+
+    // Display the form, and put the right buttons in place.
+    print('
+    $("#import_scheduler_dialog").html("' . $sFormNewScreening . '<BR>");
+
+    // Select the right buttons.
+    $("#import_scheduler_dialog").dialog({buttons: $.extend({}, oButtonFormNewScreening, oButtonCancel)});
+    ');
+    exit;
+}
+
+
+
+
+
+if (ACTION == 'new_screening' && POST) {
+    // Process form to reschedule a file.
+    // We do this in two steps, to prevent CSRF.
+
+    if (empty($_POST['csrf_token']) || $_POST['csrf_token'] != $_SESSION['csrf_tokens']['import_scheduler_new_screening']) {
+        die('alert("Error while sending data, possible security risk. Try reloading the page, and loading the form again.");');
+    }
+
+    // Find original Individual.
+    $nID = $_DB->query('SELECT id FROM ' . TABLE_INDIVIDUALS . ' WHERE `Individual/Lab_ID` = ?',
+        array($aParsed['Individuals']['Individual/Lab_ID']))->fetchColumn();
+    if (!$nID) {
+        die('alert("Error: Could not find original Individual entry in the database. I will not try and edit this file.\n");');
+    }
+
+    // Unfortunately, we cannot easily just remove or edit a line.
+    // We have to loop through the contents, edit in memory, and overwrite the entire file.
+    // This will take a lot of memory, but oh well.
+    $aMetaData = file($_INI['paths']['data_files'] . '/' . $sFile); // Leaving line endings on purpose.
+    $sSection = '';
+    $bHeaderPrevRow = false;
+    $bSuccess = false;
+    foreach ($aMetaData as $i => $sLine) {
+        if (!trim($sLine)) {
+            continue;
+        } elseif (preg_match('/^##\s*([A-Za-z_]+)\s*##\s*Do not remove/', ltrim($sLine, '"'), $aRegs)) {
+            // New section. Get rid of the Individuals data, and edit the Screenings data.
+            $sSection = $aRegs[1];
+            $bHeaderPrevRow = false;
+        } elseif (substr($sLine, 0) == '#') {
+            continue;
+        } elseif (substr($sLine, 0, 3) == '"{{') {
+            // Header.
+            $bHeaderPrevRow = true;
+        } elseif ($bHeaderPrevRow) {
+            if (in_array($sSection, array('Individuals', 'Individuals_To_Diseases'))) {
+                // Kill the Individual-related data.
+                unset($aMetaData[$i-1]);
+                unset($aMetaData[$i]);
+                continue;
+            } elseif ($sSection == 'Screenings') {
+                // Edit the screenings info.
+                $aLine = array_map(function($sData) {
+                    return trim($sData, '"');
+                }, explode("\t", rtrim($sLine)));
+
+                if (array_values($aParsed['Screenings']) == $aLine) {
+                    // Full match; this is the Screenings line.
+                    // Replace individual ID, and replace line.
+                    $aParsed['Screenings']['individualid'] = $nID;
+                    $aMetaData[$i] = '"' . implode("\"\t\"", $aParsed['Screenings']) . "\"\r\n";
+                    $bSuccess = true;
+                    // No else needed here; we'll just complain later if we weren't successful.
+                    break;
+                }
+            }
+        }
+    }
+
+    if (!$bSuccess) {
+        die('alert("Error: Could not find the information to be replaced.\n");');
+    }
+
+    // Done! Move the original file, and write to new file. This prevents disastrous data corruption.
+    if (!rename($_INI['paths']['data_files'] . '/' . $sFile, $_INI['paths']['data_files'] . '/' . $sFile . '.ori')) {
+        die('alert("Error: Could not rename the original file, and I won\'t try to overwrite it.\n");');
+    }
+
+    if (!file_put_contents($_INI['paths']['data_files'] . '/' . $sFile, implode('', $aMetaData))) {
+        // Hmm.... better try and restore previous situation.
+        @unlink($_INI['paths']['data_files'] . '/' . $sFile);
+        @rename($_INI['paths']['data_files'] . '/' . $sFile . '.ori', $_INI['paths']['data_files'] . '/' . $sFile);
+        die('alert("Error: Could not write data to new file.\n");');
+    }
+
+    lovd_writeLog('Event', 'ImportReschedule', 'Successfully edited ' . $sFile . ' to be imported as a new Screening');
+
+    // Also, reschedule the file.
+    if (!$_DB->query('UPDATE ' . TABLE_SCHEDULED_IMPORTS . ' SET in_progress = 0, scheduled_by = ?, scheduled_date = NOW(), process_errors = NULL, processed_by = NULL, processed_date = NULL WHERE filename = ?', array($_AUTH['id'], $sFile), false)) {
+        die('alert("Successfully edited the file to be imported as a new Screening, but failed to reschedule.\n' . htmlspecialchars($_DB->formatError()) . '");');
+    }
+    // If we get here, the file has been successfully rescheduled!
+    lovd_writeLog('Event', 'ImportReschedule', 'Successfully rescheduled ' . $sFile);
+
+    // Display the form, and put the right buttons in place.
+    print('
+    $("#import_scheduler_dialog").html("File successfully edited to be imported as a new Screening, and rescheduled for import!");
+    setTimeout(\'window.location.href = window.location.href;\', 2000);
+    
+    // Select the right buttons.
+    $("#import_scheduler_dialog").dialog({buttons: oButtonClose}); 
     ');
     exit;
 }

--- a/src/class/object_individuals.php
+++ b/src/class/object_individuals.php
@@ -328,6 +328,7 @@ class LOVD_Individual extends LOVD_Custom
             }
             if ($r) {
                 list($nID, $sCreatedDate) = $r;
+                // NOTE: Do not just change this error message, we are parsing for it in ajax/import_scheduler.php.
                 lovd_errorAdd('Individual/Lab_ID',
                     'Another individual with this Lab ID already exists in the database; #' . $nID . ', imported ' . $sCreatedDate . '.');
             }

--- a/src/class/object_individuals.php
+++ b/src/class/object_individuals.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2019-10-09
+ * Modified    : 2019-10-28
  * For LOVD    : 3.0-22
  *
  * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
@@ -312,15 +312,24 @@ class LOVD_Individual extends LOVD_Custom
             }
         }
 
-        // Diagnostics: Don't allow individuals with an identical Lab-ID.
-        // Can't enforce this in the table, because it's a custom column that's not active during installation, so I'll just do it like this.
+        // LOVD+: Don't allow individuals with an identical Lab-ID.
+        // Can't enforce this in the table, because it's a custom column, so I'll just do it like this.
         if (LOVD_plus && !empty($aData['Individual/Lab_ID'])) {
-            if ($zData && isset($zData['id']) && isset($zData['Individual/Lab_ID'])) {
-                if ($_DB->query('SELECT id FROM ' . TABLE_INDIVIDUALS . ' WHERE `Individual/Lab_ID` = ? AND id != ?', array($aData['Individual/Lab_ID'], $zData['id']))->fetchColumn()) {
-                    lovd_errorAdd('Individual/Lab_ID', 'Another individual with this Lab ID already exists in the database.');
-                }
-            } elseif ($_DB->query('SELECT id FROM ' . TABLE_INDIVIDUALS . ' WHERE `Individual/Lab_ID` = ?', array($aData['Individual/Lab_ID']))->fetchColumn()) {
-                lovd_errorAdd('Individual/Lab_ID', 'Another individual with this Lab ID already exists in the database.');
+            if ($zData && isset($zData['id'])) {
+                $r = $_DB->query('SELECT id, created_date
+                                  FROM ' . TABLE_INDIVIDUALS . '
+                                  WHERE `Individual/Lab_ID` = ? AND id != ?',
+                        array($aData['Individual/Lab_ID'], $zData['id']))->fetchRow();
+            } else {
+                $r = $_DB->query('SELECT id, created_date
+                                  FROM ' . TABLE_INDIVIDUALS . '
+                                  WHERE `Individual/Lab_ID` = ?',
+                        array($aData['Individual/Lab_ID']))->fetchRow();
+            }
+            if ($r) {
+                list($nID, $sCreatedDate) = $r;
+                lovd_errorAdd('Individual/Lab_ID',
+                    'Another individual with this Lab ID already exists in the database; #' . $nID . ', imported ' . $sCreatedDate . '.');
             }
         }
 


### PR DESCRIPTION
Added feature to manually select a file to be imported as a new screening.
- When a file fails to import due to the Lab-ID already having been imported, add some Individual information to the error message.
- Let import scheduler recognize when the Lab-ID error showed up, so it offers to import the file as a new Screening.
- Added feature to import file as a new Screening, as an ajax action to be triggered from the import scheduling page.
  - The given Total file is edited, the original Total file is kept and renamed.
  - Actions are logged.
  - Also replaced the "Back" button with "Close" for the rescheduling confirmation dialog.
- Added data checks; the meta data file contents are now compared to the database.
  - This should reduce the chance for mistakes when perhaps reusing an ID by accident.