### PR TITLE
Fixed several issues with VCF file parsing and file processing.

### DIFF
--- a/src/scripts/adapters/adapter.lib.DEFAULT.php
+++ b/src/scripts/adapters/adapter.lib.DEFAULT.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-09-02
- * Modified    : 2019-09-26
- * For LOVD    : 3.0-22
+ * Modified    : 2020-09-09
+ * For LOVD    : 3.0-24
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Juny Kesumadewi <juny.kesumadewi@unimelb.edu.au>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
@@ -378,8 +378,10 @@ class LOVD_DefaultDataConverter {
                 // Homozygous REF; not a variant. Skip this line silently.
                 $aVariant['lovd_ignore_variant'] = 'silent';
                 break;
-            case '0/1':
-                // Heterozygous.
+            case '0/1': // Heterozygous.
+            case '0|1': // Phased heterozygous.
+                // Phased GTs are currently not handled, because we don't know if
+                //  variants have been filtered and as such we can't trust these values.
                 if (!empty($aVariant['VariantOnGenome/Sequencing/Father/GenoType']) && !empty($aVariant['VariantOnGenome/Sequencing/Mother/GenoType'])) {
                     if (strpos($aVariant['VariantOnGenome/Sequencing/Father/GenoType'], '1') !== false && strpos($aVariant['VariantOnGenome/Sequencing/Mother/GenoType'], '1') === false) {
                         // From father, inferred.
@@ -394,8 +396,11 @@ class LOVD_DefaultDataConverter {
                     $aVariant['allele'] = 0;
                 }
                 break;
-            case '1/1':
-                // Homozygous.
+            case '1': // Hemizygous (LOVD doesn't have a separate allele value for this).
+            case '1/1': // Homozygous.
+            case '1|1': // Phased homozygous.
+                // Phased GTs are currently not handled, because we don't know if
+                //  variants have been filtered and as such we can't trust these values.
                 $aVariant['allele'] = 3;
                 break;
             default:

--- a/src/scripts/convert_and_merge_data_files.php
+++ b/src/scripts/convert_and_merge_data_files.php
@@ -364,6 +364,21 @@ function lovd_getVariantPosition ($sVariant, $aTranscript = array())
             $aReturn['end'] = $aReturn['start'];
             $aReturn['end_intron'] = $aReturn['start_intron'];
         }
+
+        // If a variant is described poorly with a start > end, then we'll swap the positions so we will store them correctly.
+        if ($aReturn['start'] > $aReturn['end']) {
+            // There's many ways of doing this, but this method is the simplest to read.
+            $nTmp = $aReturn['start'];
+            $aReturn['start'] = $aReturn['end'];
+            $aReturn['end'] = $nTmp;
+
+            // And intronic, if needed.
+            if ($aReturn['start_intron'] || $aReturn['end_intron']) {
+                $nTmp = $aReturn['start_intron'];
+                $aReturn['start_intron'] = $aReturn['end_intron'];
+                $aReturn['end_intron'] = $nTmp;
+            }
+        }
     }
 
     return $aReturn;

--- a/src/scripts/convert_and_merge_data_files.php
+++ b/src/scripts/convert_and_merge_data_files.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2014-11-28
- * Modified    : 2019-06-19
- * For LOVD+   : 3.0-18
+ * Modified    : 2020-09-09
+ * For LOVD+   : 3.0-24
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Anthony Marty <anthony.marty@unimelb.edu.au>
  *               Juny Kesumadewi <juny.kesumadewi@unimelb.edu.au>
@@ -839,9 +839,9 @@ foreach ($aFiles as $sFileID) {
 
                     // Create the gene, with whatever info we have.
                     if (!$_DB->query('INSERT INTO ' . TABLE_GENES . '
-                         (id, name, chromosome, chrom_band, refseq_genomic, refseq_UD, reference, url_homepage, url_external, allow_download, allow_index_wiki, id_hgnc, id_entrez, id_omim, show_hgmd, show_genecards, show_genetests, note_index, note_listing, refseq, refseq_url, disclaimer, disclaimer_text, header, header_align, footer, footer_align, created_by, created_date, updated_by, updated_date)
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), ?, NOW())',
-                        array($aGeneInfo['symbol'], $aGeneInfo['name'], $aGeneInfo['chromosome'], $aGeneInfo['chrom_band'], $_SETT['human_builds'][$_CONF['refseq_build']]['ncbi_sequences'][$aGeneInfo['chromosome']], '', '', '', '', 0, 0, $aGeneInfo['hgnc_id'], $aGeneInfo['entrez_id'], (!$aGeneInfo['omim_id']? NULL : $aGeneInfo['omim_id']), 0, 0, 0, '', '', '', '', 0, '', '', 0, '', 0, 0, 0))
+                        (id, name, chromosome, chrom_band, refseq_genomic, refseq_UD, reference, url_homepage, url_external, allow_download, id_hgnc, id_entrez, id_omim, show_hgmd, show_genecards, show_genetests, note_index, note_listing, refseq, refseq_url, disclaimer, disclaimer_text, header, header_align, footer, footer_align, created_by, created_date, updated_by, updated_date)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), ?, NOW())',
+                        array($aGeneInfo['symbol'], $aGeneInfo['name'], $aGeneInfo['chromosome'], $aGeneInfo['chrom_band'], $_SETT['human_builds'][$_CONF['refseq_build']]['ncbi_sequences'][$aGeneInfo['chromosome']], '', '', '', '', 0, $aGeneInfo['hgnc_id'], $aGeneInfo['entrez_id'], (!$aGeneInfo['omim_id']? NULL : $aGeneInfo['omim_id']), 0, 0, 0, '', '', '', '', 0, '', '', 0, '', 0, 0, 0))
                     ) {
                         $sMessage = 'Can\'t create gene ' . $aVariant['symbol'] . '.';
                         lovd_printIfVerbose(VERBOSITY_LOW, $sMessage . "\n");


### PR DESCRIPTION
Fixed several issues with VCF file parsing and file processing.
- Fixed bug; The conversion script could no longer create genes after the update to the LOVD 3.0-23 backend.
- Fixed import problem when VEP sometimes provides a cDNA description with the positions swapped.
  - The conversion script now corrects the position fields so the import will be accepted. The DNA field is currently not yet fixed.
- Added rudimentary support for phased data; we currently just treat it as unphased data.
- Fixed bug; ALT alleles of * in VCF 4.2 files disrupted the parsing of the Ensembl VEP annotation.

Closes #10.