### PR TITLE
Use VariantValidator

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/libs/HGVS-syntax-checker"]
+	path = src/libs/HGVS-syntax-checker
+	url = git@github.com:LOVDnl/HGVS-syntax-checker.git

--- a/doc/tex/LOVD+_manual.tex
+++ b/doc/tex/LOVD+_manual.tex
@@ -7,7 +7,7 @@
 % To convert the manual to an html file use: pdf2htmlEX --zoom 1.3 --embed-css 2 manual.pdf
 
 %%%%% SETTINGS FOR THE TITLE PAGE %%%%%
-\setLOVDversion{3.0-29}
+\setLOVDversion{3.0-30}
 \title{LOVD\textsuperscript{+} user manual \\
   \vskip 0.2cm Whole exome sequencing analysis \\
   \vskip 0.2cm Build \LOVDversion}
@@ -522,13 +522,20 @@ To automate the file conversion on Linux servers,
 To run it just once, open the \texttt{scripts} folder from your browser and run the
  \texttt{convert\_and\_merge\_data\_files.php} script.
 
+The data conversion makes use of the LOVD HGVS syntax checker library.
+This library contains a gene cache, that should be updated regularly.
+There is an update script available that will update the gene cache if it's a week old or older.
+You can automate running this updater by using a crontab as well.
+
 \begin{figure}[ht]
   \begin{shaded}
 \begin{verbatim}
 */15 * * * * php -f /path_to_LOVD+/scripts/convert_and_merge_data_files.php
+  45 5 * * 0 php -f /path_to_LOVD+/libs/HGVS-syntax-checker/cache/update.php
 \end{verbatim}
   \caption{%
     Example cronjob to facilitate automatic conversion of meta and data files into LOVD import files.
+    The second cronjob is to make sure that the gene cache gets refreshed every week.
     Make sure the directory in which `php' resides, is in the PATH environment variable.
     Also, change ``\texttt{path\_to\_LOVD+}'' to the full path of your LOVD\textsuperscript{+} installation.
     Feel free to change the time settings, but note that running the conversion script in parallel

--- a/doc/tex/config.tex
+++ b/doc/tex/config.tex
@@ -101,7 +101,7 @@
 %   can provide diagnosis as well as help predict the likelihood of developing a particular
 %   disease before symptoms occur, using data from LOVD databases.
 %  \vskip1em
-  \vskip 8em
+  \vskip 9em
   \noindent
   For more information regarding the LOVD\textsuperscript{+} software, please see \url{http://LOVD.nl/plus}.
 

--- a/src/INSTALL.txt
+++ b/src/INSTALL.txt
@@ -77,7 +77,7 @@ Then, for any user with write access to the data directory insert the following
 cronjob to facilitate automatic conversion of meta and data files into LOVD+
 import files:
 
-*/15 * * * * php -f /path_to_LOVD/scripts/convert_and_merge_data_files.php
+*/15 * * * * php -f /path_to_LOVD+/scripts/convert_and_merge_data_files.php
 
 Make sure the directory in which `php` resides, is in the PATH environment
 variable. Feel free to change the time settings, but note that running the
@@ -89,6 +89,13 @@ the number of genes and transcripts from the data files that are not yet
 imported into LOVD+. The conversion of data files does not interfere with normal
 functionality of LOVD+, and as such can run 24 hours a day, also whenever LOVD+
 is in use.
+
+The data conversion makes use of the LOVD HGVS syntax checker library. This
+library contains a gene cache, that should be updated regularly. There is an
+update script available that will update the gene cache if it's a week old or
+older. You can automate running this updater by using a crontab as well, e.g.:
+
+45 5 * * 0 php -f /path_to_LOVD+/libs/HGVS-syntax-checker/cache/update.php
 
 Converted files can be scheduled for automatic import by the scheduling feature
 available from the Setup area. To facilitate automatic import of the scheduled

--- a/src/docs/index.php
+++ b/src/docs/index.php
@@ -47,7 +47,7 @@ if (PATH_COUNT == 1 && !ACTION) {
     if (LOVD_plus) {
         print('      Currently available is the LOVD+ user manual, in PDF format.<BR>' .
               '      <UL>' . "\n" .
-              '        <LI>LOVD manual 3.0-29 (<A href="docs/LOVD+_manual.pdf" target="_blank"><B>PDF</B>, 22 pages, 1.2Mb</A>) - last updated October 16th, 2023</LI></UL>' . "\n\n");
+              '        <LI>LOVD manual 3.0-30 (<A href="docs/LOVD+_manual.pdf" target="_blank"><B>PDF</B>, 22 pages, 1.2Mb</A>) - last updated August 20th, 2025</LI></UL>' . "\n\n");
     } else {
         print('      Currently available is the LOVD 3.0 user manual, in PDF and HTML formats.<BR>' .
               '      <UL>' . "\n" .

--- a/src/scripts/adapters/adapter.lib.DEFAULT.php
+++ b/src/scripts/adapters/adapter.lib.DEFAULT.php
@@ -569,9 +569,9 @@ class LOVD_DefaultDataConverter {
 
         $aColumnMappings = array(
             '#CHROM' => 'chromosome',
-            'POS' => 'position', // lovd_getVariantDescription() needs this.
-            'REF' => 'ref',      // lovd_getVariantDescription() needs this.
-            'ALT' => 'alt',      // lovd_getVariantDescription() needs this.
+            'POS' => 'position', // We need this to construct the DNA field.
+            'REF' => 'ref',      // We need this to construct the DNA field.
+            'ALT' => 'alt',      // We need this to construct the DNA field.
             'QUAL' => 'VariantOnGenome/Sequencing/Quality',
             'FILTER' => 'VariantOnGenome/Sequencing/Filter',
             'Consequence' => 'VariantOnTranscript/GVS/Function', // Will be translated.

--- a/src/scripts/adapters/adapter.lib.DEFAULT.php
+++ b/src/scripts/adapters/adapter.lib.DEFAULT.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-09-02
- * Modified    : 2022-12-09
- * For LOVD    : 3.0-29
+ * Modified    : 2025-07-15
+ * For LOVD    : 3.0-30
  *
- * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2025 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Juny Kesumadewi <juny.kesumadewi@unimelb.edu.au>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
@@ -576,7 +576,7 @@ class LOVD_DefaultDataConverter {
             'FILTER' => 'VariantOnGenome/Sequencing/Filter',
             'Consequence' => 'VariantOnTranscript/GVS/Function', // Will be translated.
             'SYMBOL' => 'symbol',
-            'Feature' => 'transcriptid',
+            'Feature' => 'id_ncbi',
             'HGVSc' => 'VariantOnTranscript/DNA',
             'HGVSp' => 'VariantOnTranscript/Protein',
             'Existing_variation' => 'existing_variation', // This is where we'll find the dbSNP data.

--- a/src/scripts/adapters/adapter.lib.LEIDEN.php
+++ b/src/scripts/adapters/adapter.lib.LEIDEN.php
@@ -1072,7 +1072,7 @@ class LOVD_LeidenDataConverter extends LOVD_DefaultDataConverter {
 
         $aColumnMappings = array(
             'chromosome' => 'chromosome',
-            'position' => 'position', // lovd_getVariantDescription() needs this.
+            'position' => 'position', // We need this to construct the DNA field.
             'QUAL' => 'VariantOnGenome/Sequencing/Quality',
             'FILTERvcf' => 'VariantOnGenome/Sequencing/Filter',
             'Consequence' => 'VariantOnTranscript/GVS/Function', // Will be translated.
@@ -1129,7 +1129,7 @@ class LOVD_LeidenDataConverter extends LOVD_DefaultDataConverter {
 
             // Mappings for fields used to process other fields but not imported into the database.
             'SYMBOL' => 'symbol',
-            'HGNC_ID' => 'id_hgnc',
+            'HGNC' => 'id_hgnc',
             'REF' => 'ref',
             'ALT' => 'alt',
             'Existing_variation' => 'existing_variation'

--- a/src/scripts/adapters/adapter.lib.LEIDEN.php
+++ b/src/scripts/adapters/adapter.lib.LEIDEN.php
@@ -1077,7 +1077,7 @@ class LOVD_LeidenDataConverter extends LOVD_DefaultDataConverter {
             'FILTERvcf' => 'VariantOnGenome/Sequencing/Filter',
             'Consequence' => 'VariantOnTranscript/GVS/Function', // Will be translated.
             // 'GATKCaller' => 'VariantOnGenome/Sequencing/GATKcaller',
-            'Feature' => 'transcriptid',
+            'Feature' => 'id_ncbi',
             'CDS_position' => 'VariantOnTranscript/Position',
             'HGVSc' => 'VariantOnTranscript/DNA',
             'HGVSp' => 'VariantOnTranscript/Protein',

--- a/src/scripts/adapters/adapter.lib.MGHA.php
+++ b/src/scripts/adapters/adapter.lib.MGHA.php
@@ -308,7 +308,7 @@ class LOVD_MghaDataConverter extends LOVD_DefaultDataConverter {
             'ALT' => 'alt',
             'vog_alt' => 'VariantOnGenome/Alt',
             'Existing_variation' => 'existing_variation',
-            'Feature' => 'transcriptid',
+            'Feature' => 'id_ncbi',
             // VariantOnGenome/DNA - constructed by the HGVS syntax checker later on.
             'CHROM' => 'chromosome',
             'POS' => 'position', // We need this to construct the DNA field.
@@ -900,7 +900,7 @@ class LOVD_MghaDataConverter extends LOVD_DefaultDataConverter {
 
 
 
-    function postValueAssignmentUpdate($sKey, &$aVariant, &$aData)
+    function postValueAssignmentUpdate ($sKey, &$aVariant, &$aData)
     {
         // Update $aData if there is any aggregated data that we need to update after each input line is read.
         // 0 index in  $aData[$sKey] is where we store the VOG data

--- a/src/scripts/adapters/adapter.lib.MGHA.php
+++ b/src/scripts/adapters/adapter.lib.MGHA.php
@@ -309,9 +309,9 @@ class LOVD_MghaDataConverter extends LOVD_DefaultDataConverter {
             'vog_alt' => 'VariantOnGenome/Alt',
             'Existing_variation' => 'existing_variation',
             'Feature' => 'transcriptid',
-            // VariantOnGenome/DNA - constructed by the lovd_getVariantDescription function later on.
+            // VariantOnGenome/DNA - constructed by the HGVS syntax checker later on.
             'CHROM' => 'chromosome',
-            'POS' => 'position', // lovd_getVariantDescription() needs this.
+            'POS' => 'position', // We need this to construct the DNA field.
             'vog_pos' => 'VariantOnGenome/Position',
             'ID' => 'VariantOnGenome/dbSNP',
             'QUAL' => 'VariantOnGenome/Sequencing/Quality',

--- a/src/scripts/adapters/adapter.lib.MGHA_CPIPE_LYMPHOMA.php
+++ b/src/scripts/adapters/adapter.lib.MGHA_CPIPE_LYMPHOMA.php
@@ -220,7 +220,7 @@ class LOVD_MghaCpipeLymphomaDataConverter extends LOVD_MghaDataConverter {
             'ALT' => 'alt',
             'vog_alt' => 'VariantOnGenome/Alt',
             'Existing_variation' => 'existingvariation',
-            'Feature' => 'transcriptid',
+            'Feature' => 'id_ncbi',
             // VariantOnGenome/DNA - constructed by the HGVS syntax checker later on.
             'CHROM' => 'chromosome',
             'POS' => 'position', // We need this to construct the DNA field.

--- a/src/scripts/adapters/adapter.lib.MGHA_CPIPE_LYMPHOMA.php
+++ b/src/scripts/adapters/adapter.lib.MGHA_CPIPE_LYMPHOMA.php
@@ -221,9 +221,9 @@ class LOVD_MghaCpipeLymphomaDataConverter extends LOVD_MghaDataConverter {
             'vog_alt' => 'VariantOnGenome/Alt',
             'Existing_variation' => 'existingvariation',
             'Feature' => 'transcriptid',
-            // VariantOnGenome/DNA - constructed by the lovd_getVariantDescription function later on.
+            // VariantOnGenome/DNA - constructed by the HGVS syntax checker later on.
             'CHROM' => 'chromosome',
-            'POS' => 'position', // lovd_getVariantDescription() needs this.
+            'POS' => 'position', // We need this to construct the DNA field.
             'vog_pos' => 'VariantOnGenome/Position',
             'ID' => 'VariantOnGenome/dbSNP',
             'QUAL' => 'VariantOnGenome/Sequencing/Quality',

--- a/src/scripts/adapters/adapter.lib.MGHA_SEQ.php
+++ b/src/scripts/adapters/adapter.lib.MGHA_SEQ.php
@@ -189,7 +189,7 @@ class LOVD_MghaSeqDataConverter extends LOVD_DefaultDataConverter {
             'QUAL' => 'VariantOnGenome/Sequencing/Quality',
             'SYMBOL' => 'symbol',
 
-            'Feature' => 'transcriptid',
+            'Feature' => 'id_ncbi',
             'HGVSc' => 'VariantOnTranscript/DNA',
             'HGVSp' => 'VariantOnTranscript/Protein',
 
@@ -637,7 +637,7 @@ class LOVD_MghaSeqDataConverter extends LOVD_DefaultDataConverter {
 
 
 
-    function postValueAssignmentUpdate($sKey, &$aVariant, &$aData)
+    function postValueAssignmentUpdate ($sKey, &$aVariant, &$aData)
     {
         // We want to use different BAM file for different screening types.
         $aLinkTypes = array();

--- a/src/scripts/convert_and_merge_data_files.php
+++ b/src/scripts/convert_and_merge_data_files.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2014-11-28
- * Modified    : 2025-08-13
+ * Modified    : 2025-08-14
  * For LOVD+   : 3.0-30
  *
  * Copyright   : 2004-2025 Leiden University Medical Center; http://www.LUMC.nl/
@@ -944,34 +944,33 @@ foreach ($aFiles as $sFileID) {
                 }
             }
 
-            // For the position fields, VEP can generate data (CDS_position), but it's hardly usable. Calculate ourselves.
-            // 2022-12-09; Updated to use LOVD's lovd_getVariantInfo() instead of LOVD+'s lovd_getVariantPosition().
-            // However, Mutalyzer gives us positions that aren't possible like n.-100 and n.*100. This happens when a
-            //  variant can't actually be mapped to a transcript. lovd_getVariantInfo() is too smart and doesn't allow
-            //  this and returns 0 as position. This won't allow us to sort these variants in the views. Therefore,
-            //  better manipulate lovd_getVariantInfo() to anyway get us positions by making it think we're submitting
-            //  c. variants.
-            $aVariantInfo = lovd_getVariantInfo(
-                str_replace('n.', 'c.', $aVariant['VariantOnTranscript/DNA']),
-                $aTranscripts[$aVariant['id_ncbi']]
-            );
-            if ($aVariantInfo) {
-                list(
-                    $aVariant['position_c_start'],
-                    $aVariant['position_c_start_intron'],
-                    $aVariant['position_c_end'],
-                    $aVariant['position_c_end_intron']
-                ) = array(
-                    $aVariantInfo['position_start'],
-                    (empty($aVariantInfo['position_start_intron'])? 0 : $aVariantInfo['position_start_intron']),
-                    $aVariantInfo['position_end'],
-                    (empty($aVariantInfo['position_end_intron'])? 0 : $aVariantInfo['position_end_intron']),
-                );
+            // If everything failed, choose a default.
+            if (!$aVariant['VariantOnTranscript/DNA']) {
+                $aVariant['VariantOnTranscript/DNA'] = 'c.?';
             }
+
+            // For the position fields, VEP can generate data (CDS_position), but it's hardly usable. Calculate ourselves.
+            $aVariantInfo = lovd_getVariantInfo($aVariant['VariantOnTranscript/DNA'], $aTranscripts[$aVariant['id_ncbi']]);
+            list(
+                $aVariant['position_c_start'],
+                $aVariant['position_c_start_intron'],
+                $aVariant['position_c_end'],
+                $aVariant['position_c_end_intron'],
+            ) = array(
+                ($aVariantInfo['position_start'] ?? 0),
+                ($aVariantInfo['position_start_intron'] ?? 0),
+                ($aVariantInfo['position_end'] ?? 0),
+                ($aVariantInfo['position_end_intron'] ?? 0),
+            );
 
             // VariantOnTranscript/Position is an integer column; so just copy the c_start.
             $aVariant['VariantOnTranscript/Position'] = $aVariant['position_c_start'];
-            $aVariant['VariantOnTranscript/Distance_to_splice_site'] = ((bool) $aVariant['position_c_start_intron'] == (bool) $aVariant['position_c_end_intron']? min(abs($aVariant['position_c_start_intron']), abs($aVariant['position_c_end_intron'])) : ($aVariant['position_c_start_intron']? abs($aVariant['position_c_start_intron']) : abs($aVariant['position_c_end_intron'])));
+            // Calculate the "DistanceToSplice" ourselves. That's easy to do, so we won't have to rely on it.
+            $aVariant['VariantOnTranscript/Distance_to_splice_site'] =
+                ((bool) $aVariant['position_c_start_intron'] == (bool) $aVariant['position_c_end_intron']?
+                    min(abs($aVariant['position_c_start_intron']), abs($aVariant['position_c_end_intron'])) :
+                    ($aVariant['position_c_start_intron']?
+                        abs($aVariant['position_c_start_intron']) : abs($aVariant['position_c_end_intron'])));
 
             // VariantOnTranscript/RNA && VariantOnTranscript/Protein.
             // Try to do as much as possible by ourselves.

--- a/src/scripts/convert_and_merge_data_files.php
+++ b/src/scripts/convert_and_merge_data_files.php
@@ -884,6 +884,16 @@ foreach ($aFiles as $sFileID) {
             $aVariant['VariantOnTranscript/DNA/VEP'] = $aVariant['VariantOnTranscript/DNA'];
             if ($bCallVV) {
                 // We don't have a DNA field from VEP, or we don't trust it (see above).
+                // Speed things up and reduce API calls by checking our own database, first. Fetch the most recent mapping from the same variant.
+                lovd_printIfVerbose(VERBOSITY_FULL, 'Checking our database for mapping info, DNA was: "' . $aVariant['VariantOnTranscript/DNA'] . '"' . "\n");
+                $aMapping = $_DB->q('
+                    SELECT vot.`VariantOnTranscript/DNA`, vot.`VariantOnTranscript/RNA`, vot.`VariantOnTranscript/Protein`
+                    FROM ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot
+                      INNER JOIN ' . TABLE_VARIANTS . ' AS vog ON (vot.id = vog.id)
+                    WHERE vot.transcriptid = ? AND vog.chromosome = ? AND vog.position_g_start = ? AND vog.position_g_end = ? AND vog.`VariantOnGenome/DNA` = ?
+                    ORDER BY vog.id DESC LIMIT 1',
+                    array($aTranscripts[$aVariant['id_ncbi']]['id'], $aVariant['chromosome'], $aVariant['position_g_start'], $aVariant['position_g_end'], substr(strstr($aVariant['VariantOnGenome/DNA'], ':'), 1)))->fetchAllAssoc();
+
                 // Call Mutalyzer, but first check if I did that before already.
                 if (empty($aMappings)) {
                     $aMappings = array();

--- a/src/scripts/convert_and_merge_data_files.php
+++ b/src/scripts/convert_and_merge_data_files.php
@@ -63,26 +63,6 @@ if (!empty($_CONF['proxy_username']) && !empty($_CONF['proxy_password'])) {
     curl_setopt($ch, CURLOPT_PROXYUSERPWD, $_CONF['proxy_username'] . ':' . $_CONF['proxy_password']);
 }
 
-function mutalyzer_numberConversion ($build, $variant)
-{
-    global $ch, $_CONF;
-
-    $sUrl = str_replace('/services', '', $_CONF['mutalyzer_soap_url']) . '/json/numberConversion?build=' . $build . '&variant=' . $variant;
-    curl_setopt($ch, CURLOPT_URL, $sUrl);
-
-    return curl_exec($ch);
-}
-
-function mutalyzer_runMutalyzer ($variant)
-{
-    global $ch, $_CONF;
-
-    $sUrl = str_replace('/services', '', $_CONF['mutalyzer_soap_url']) . '/json/runMutalyzerLight?variant=' . $variant;
-    curl_setopt($ch, CURLOPT_URL, $sUrl);
-
-    return curl_exec($ch);
-}
-
 
 
 
@@ -158,7 +138,6 @@ $aDefaultValues = array(
 
 
 
-$nMutalyzerRetries = 5; // The number of times we retry the Mutalyzer API call if the connection fails.
 $nFilesBeingMerged = 0; // We're counting how many files are being merged at the time, because we don't want to stress the system too much.
 $nMaxFilesBeingMerged = 5; // We're allowing only five processes working concurrently on merging files (or so many failed attempts that have not been cleaned up).
 $aFiles = array(); // array(ID => array(files), ...);
@@ -403,12 +382,11 @@ foreach ($aFiles as $sFileID) {
 
     // Now start parsing the file, reading it out line by line, building up the variant data in $aData.
     $dStart = time();
-    $aMutalyzerCalls = array(
-        'getTranscriptsAndInfo' => 0,
-        'numberConversion' => 0,
-        'runMutalyzer' => 0,
+    $aVVCalls = array(
+        'getTranscriptsByID' => 0,
+        'verifyGenomicAndPredictProtein' => 0,
     );
-    $tMutalyzerCalls = 0; // Time spent doing Mutalyzer calls.
+    $tVVCalls = 0; // Time spent doing VV calls.
     $aData = array(); // 'chr1:1234567C>G' => array(array(genomic_data), array(transcript1), array(transcript2), ...)
     lovd_printIfVerbose(VERBOSITY_LOW, 'Parsing file. Current time: ' . date('Y-m-d H:i:s') . ".\n");
     flush();
@@ -420,7 +398,6 @@ foreach ($aFiles as $sFileID) {
     $aTranscripts = array(); // NM_000001.1 => array(<transcript_info>)
     $nHGNC = 0; // Count the number of times HGNC is called.
     $tHGNCCalls = 0; // Time spent doing HGNC calls.
-    $nMutalyzer = 0; // Count the number of times Mutalyzer is called.
     $nAnnotationErrors = 0; // Count the number of lines we cannot import.
 
     // Get all the existing genes in one database call.
@@ -759,11 +736,10 @@ foreach ($aFiles as $sFileID) {
                     lovd_printIfVerbose(VERBOSITY_HIGH, 'Loading transcript information for ' . $aGenes[$aVariant['symbol']]['id'] . '...' . "\n");
 
                     // Fetch the transcripts using the HGNC ID, so we won't have issues with gene symbols.
-                    $tMutalyzerStart = microtime(true);
+                    $tVVStart = microtime(true);
                     $aTranscriptInfo = $_VV->getTranscriptsByID('HGNC:' . $aGenes[$aVariant['symbol']]['id_hgnc']);
-                    $tMutalyzerCalls += (microtime(true) - $tMutalyzerStart);
-                    $aMutalyzerCalls['getTranscriptsAndInfo']++;
-                    $nMutalyzer++;
+                    $tVVCalls += (microtime(true) - $tVVStart);
+                    $aVVCalls['getTranscriptsByID']++;
 
                     if (!$aTranscriptInfo || !empty($aTranscriptInfo['errors'])) {
                         // Something went wrong. Let the user know.
@@ -890,11 +866,10 @@ foreach ($aFiles as $sFileID) {
                 if (!$aMapping) {
                     lovd_printIfVerbose(VERBOSITY_FULL, 'Running VariantValidator, DNA was: "' . $aVariant['VariantOnTranscript/DNA'] . '"' . "\n");
 
-                    $tMutalyzerStart = microtime(true);
+                    $tVVStart = microtime(true);
                     $aVV = $_VV->verifyGenomicAndPredictProtein($aVariant['VariantOnGenome/DNA'], $aVariant['id_ncbi']);
-                    $tMutalyzerCalls += (microtime(true) - $tMutalyzerStart);
-                    $aMutalyzerCalls['numberConversion']++;
-                    $nMutalyzer++;
+                    $tVVCalls += (microtime(true) - $tVVStart);
+                    $aVVCalls['verifyGenomicAndPredictProtein']++;
 
                     // Check if we got anything at all.
                     if (!$aVV || empty($aVV['data']['DNA'])) {
@@ -1107,13 +1082,14 @@ foreach ($aFiles as $sFileID) {
     fclose($fInput); // Close input file.
 
     lovd_printIfVerbose(VERBOSITY_MEDIUM, str_repeat('-', 70) . "\n" . 'Done parsing file. Current time: ' . date('Y-m-d H:i:s') . ".\n");
-    // Show the number of times HGNC and Mutalyzer were called.
+    // Show the number of times HGNC and VariantValidator were called.
+    $nVV = array_sum($aVVCalls);
     lovd_printIfVerbose(VERBOSITY_MEDIUM,
         'Number of times HGNC called: ' . $nHGNC . (!$nHGNC? '' :
             ', taking ' . round($tHGNCCalls/60) . ' minutes, ' . round($tHGNCCalls/$nHGNC, 2) . ' sec/call') . ".\n" .
-        'Number of times Mutalyzer called: ' . $nMutalyzer . (!$nMutalyzer? '' :
-            ', taking ' . round($tMutalyzerCalls/60) . ' minutes, ' . round($tMutalyzerCalls/$nMutalyzer, 2) . ' sec/call') . ".\n");
-    foreach ($aMutalyzerCalls as $sFunction => $nCalls) {
+        'Number of times VariantValidator called: ' . $nVV . (!$nVV? '' :
+            ', taking ' . round($tVVCalls/60) . ' minutes, ' . round($tVVCalls/$nVV, 2) . ' sec/call') . ".\n");
+    foreach ($aVVCalls as $sFunction => $nCalls) {
         lovd_printIfVerbose(VERBOSITY_MEDIUM, '  ' . $sFunction . ': ' . $nCalls . "\n");
     }
     lovd_printIfVerbose(VERBOSITY_MEDIUM, 'Parsing took ' . round((time() - $dStart)/60) . ' minutes in total.' . "\n" .

--- a/src/scripts/convert_and_merge_data_files.php
+++ b/src/scripts/convert_and_merge_data_files.php
@@ -997,11 +997,11 @@ foreach ($aFiles as $sFileID) {
         }
 
         // DNA fields and protein field can be super long with long inserts.
-        // For the DNA fields, shorten insAAAAAA to ins(6), for DNA descriptions >100 characters.
+        // For the DNA fields, shorten insAAAAAA to insN[6], for DNA descriptions >100 characters.
         // FIXME: Better make this dependent on the field length; there are LOVDs out there that allow more data, and they should get it.
         foreach (array('VariantOnGenome/DNA', 'VariantOnTranscript/DNA') as $sField) {
             if (isset($aVariant[$sField]) && strlen($aVariant[$sField]) > 100 && preg_match('/ins([ACTG]+)$/', $aVariant[$sField], $aRegs)) {
-                $aVariant[$sField] = str_replace('ins' . $aRegs[1], 'ins(' . strlen($aRegs[1]) . ')', $aVariant[$sField]);
+                $aVariant[$sField] = str_replace('ins' . $aRegs[1], 'insN[' . strlen($aRegs[1]) . ']', $aVariant[$sField]);
             }
         }
         // Don't put this in the output file.
@@ -1011,9 +1011,9 @@ foreach ($aFiles as $sFileID) {
         // FIXME: Better make this dependent on the field length; there are LOVDs out there that allow more data, and they should get it.
         $sField = 'VariantOnTranscript/Protein';
         if (isset($aVariant[$sField]) && strlen($aVariant[$sField]) > 100) {
-            // For the protein field, shorten insArgArgArg to ins(3), for protein descriptions >100 characters.
+            // For the protein field, shorten insArgArgArg to insXaa[3], for protein descriptions >100 characters.
             if (preg_match('/ins(([A-Z][a-z]{2})+)\)$/', $aVariant[$sField], $aRegs)) {
-                $aVariant[$sField] = str_replace('ins' . $aRegs[1], 'ins(' . strlen($aRegs[1]) . ')', $aVariant[$sField]);
+                $aVariant[$sField] = str_replace('ins' . $aRegs[1], 'insXaa[' . strlen($aRegs[1]) . ']', $aVariant[$sField]);
             }
             // Vep produces interestingly long deletions and duplications as well.
             // p.TerSerProProGlyLysProGlnGlyProProProGlnGlyGlyAsnGlnProGlnGlyProProProProProGlyLysProGlnGlyProProProGlnGlyGlyLysLysProGlnGlyProProProProGlyLysProGlnGlyProProProGlnGlyAspLysSerArgSerSer152del -> p.Ter152_Ser212del

--- a/src/scripts/convert_and_merge_data_files.php
+++ b/src/scripts/convert_and_merge_data_files.php
@@ -849,25 +849,40 @@ foreach ($aFiles as $sFileID) {
 
         } else { // We'll handle this transcript.
             // Handle the rest of the VOT columns.
-            // First, take off the transcript name, so we can easily check for a del/ins checking for an underscore.
-            $aVariant['VariantOnTranscript/DNA'] = substr($aVariant['VariantOnTranscript/DNA'], strpos($aVariant['VariantOnTranscript/DNA'], ':')+1); // NM_000000.1:c.1del -> c.1del
+            if ($aVariant['VariantOnTranscript/DNA']) {
+                // First, take off the transcript name, so we can easily check for a del/ins checking for an underscore.
+                $aVariant['VariantOnTranscript/DNA'] = substr(strstr($aVariant['VariantOnTranscript/DNA'], ':'), 1); // NM_000000.1:c.1del -> c.1del.
+            } else {
+                // No DNA field. We accept that in a few cases.
+                if (!empty($aVariant['VariantOnTranscript/GVS/Function']) && in_array($aVariant['VariantOnTranscript/GVS/Function'], ['utr-3', 'utr-5', 'intergenic'])) {
+                    $aVariant['VariantOnTranscript/DNA'] = 'c.?';
+                }
+            }
 
-            // Decide if we need to call Mutalyzer's position converter to generate the VOT/DNA.
+            // Decide if we need to call VV to generate the VOT data (DNA, RNA, protein).
             // For sure, we need to do so, when there is no VOT/DNA from VEP.
-            $bCallMutalyzer = (!$aVariant['VariantOnTranscript/DNA']);
+            $bCallVV = (!$aVariant['VariantOnTranscript/DNA']);
+
+            // If we don't have a protein change, we may also want to check.
+            if (!$bCallVV && empty($aVariant['VariantOnTranscript/Protein'])) {
+                // However, if we have information from VEP that this is an UTR or intronic variant, never mind.
+                $bCallVV = !(!empty($aVariant['VariantOnTranscript/GVS/Function'])
+                    && in_array($aVariant['VariantOnTranscript/GVS/Function'], ['utr-3', 'utr-5', 'intergenic', 'intron', 'non-coding-exon', 'non-coding-intron-near-splice', 'splice']));
+            }
+
             // If VEP did come up with something, check if this LOVD+ instance trusts VEP's output for indels.
             if ($_INSTANCE_CONFIG['conversion']['check_indel_description']) {
                 // This LOVD+ instance chooses to ignore VEP's predictions looking like indels.
                 // VEP doesn't understand that when the gene is on reverse, they have to switch the positions.
                 // Also, sometimes a delins is simply a substitution, when the VCF file was complicated (ACGT to ACCT for example).
                 // We've also seen cases where VEP's intronic positions in the DNA field were simply wrong.
-                // Call Mutalyzer to fix these errors.
-                $bCallMutalyzer = ($bCallMutalyzer || (strpos($aVariant['VariantOnTranscript/DNA'], '_') !== false));
+                // Call VV to fix these errors.
+                $bCallVV = ($bCallVV || (strpos($aVariant['VariantOnTranscript/DNA'], '_') !== false));
             }
 
             // We still need the original later.
             $aVariant['VariantOnTranscript/DNA/VEP'] = $aVariant['VariantOnTranscript/DNA'];
-            if ($bCallMutalyzer) {
+            if ($bCallVV) {
                 // We don't have a DNA field from VEP, or we don't trust it (see above).
                 // Call Mutalyzer, but first check if I did that before already.
                 if (empty($aMappings)) {

--- a/src/scripts/convert_and_merge_data_files.php
+++ b/src/scripts/convert_and_merge_data_files.php
@@ -809,8 +809,6 @@ foreach ($aFiles as $sFileID) {
         // $aVariant['id_ncbi']                // How we received the transcript from VEP.
         // $aTranscripts[$aVariant['id_ncbi']] // The rest of the transcript information, from the database. Can be set to false.
 
-        // Store transcript ID without version, we'll use it plenty of times.
-        $aLine['transcript_noversion'] = strstr($aVariant['id_ncbi'], '.', true);
         // Now check, if we managed to get the transcript ID. If not, then we'll have to continue without it.
         if (empty($aVariant['id_ncbi']) || $_ADAPTER->ignoreTranscript($aVariant['id_ncbi']) || empty($aTranscripts[$aVariant['id_ncbi']])) {
             // When the transcript still doesn't exist, or it evaluates to false (we don't have it, we can't get it), then skip it.
@@ -994,6 +992,8 @@ foreach ($aFiles as $sFileID) {
                 $bDropTranscriptData = $_INSTANCE_CONFIG['conversion']['annotation_error_drops_line'];
             }
 
+            // Don't put this in the output file.
+            unset($aVariant['VariantOnTranscript/DNA/VEP']);
         }
 
         // DNA fields and protein field can be super long with long inserts.
@@ -1004,8 +1004,6 @@ foreach ($aFiles as $sFileID) {
                 $aVariant[$sField] = str_replace('ins' . $aRegs[1], 'insN[' . strlen($aRegs[1]) . ']', $aVariant[$sField]);
             }
         }
-        // Don't put this in the output file.
-        unset($aVariant['VariantOnTranscript/DNA/VEP']);
 
         // For the protein field, protein descriptions >100 characters can be shortened.
         // FIXME: Better make this dependent on the field length; there are LOVDs out there that allow more data, and they should get it.
@@ -1034,6 +1032,9 @@ foreach ($aFiles as $sFileID) {
         // Build the key.
         $sKey = $aVariant['chromosome'] . ':' . $aVariant['position'] . $aVariant['ref'] . '>' . $aVariant['alt'];
 
+        // Fix the VOG's DNA field, we still kept the NC in there.
+        $aVariant['VariantOnGenome/DNA'] = substr(strstr($aVariant['VariantOnGenome/DNA'], ':'), 1);
+
         if (!isset($aData[$sKey])) {
             // Create key, put in VOG data.
             $aVOG = array();
@@ -1048,7 +1049,8 @@ foreach ($aFiles as $sFileID) {
         // Perform any postprocessing, for instance based all this VOG's VOTs.
         $_ADAPTER->postValueAssignmentUpdate($sKey, $aVariant, $aData);
 
-        // Now, store VOT data. Because I had received test files with repeated lines, and allowing repeated lines will break import, also here we will check for the key.
+        // Now, store VOT data. Because I had received test files with repeated lines,
+        //  and allowing repeated lines will break import, also here we will check for the key.
         // Also check for a set transcript ID, because it can be empty (transcript could not be created).
         if (!$bDropTranscriptData && !isset($aData[$sKey][$aVariant['transcriptid']]) && $aVariant['transcriptid']) {
             $aVOT = array();

--- a/src/scripts/convert_and_merge_data_files.php
+++ b/src/scripts/convert_and_merge_data_files.php
@@ -769,30 +769,29 @@ foreach ($aFiles as $sFileID) {
                 }
 
                 // Loop transcript options, add the one we need.
-                foreach ($aTranscriptInfo as $aTranscript) {
-                    // Comparison is made without looking at version numbers!
-                    if (substr($aTranscript['id'], 0, strpos($aTranscript['id'] . '.', '.')+1) == $aLine['transcript_noversion']) {
+                foreach ($aTranscriptInfo as $sTranscript => $aTranscript) {
+                    if ($sTranscript == $aVariant['id_ncbi']) {
                         // Store in database, prepare values.
-                        $sTranscriptName = str_replace($aGenes[$aVariant['symbol']]['name'] . ', ', '', ($aTranscript['product'] ?: ''));
-                        // 2018-06-13; The getTranscriptsAndInfo() feature on NCs has a bug that the product field is empty.
-                        if (!$sTranscriptName) {
-                            $sTranscriptName = $aTranscript['id'];
-                        }
-                        $aTranscript['id_ncbi'] = $aTranscript['id'];
-                        $sTranscriptProtein = (!isset($aTranscript['proteinTranscript']['id'])? '' : $aTranscript['proteinTranscript']['id']);
-                        $aTranscript['position_c_cds_end'] = $aTranscript['cCDSStop']; // To calculate VOT variant position, if in 3'UTR.
-                        // 2018-06-13; The getTranscriptsAndInfo() feature on NCs has a bug that chrom* fields are not available.
-                        if (!isset($aTranscript['chromTransStart']) || !isset($aTranscript['chromTransEnd'])) {
-                            $aTranscript['chromTransStart'] = $aTranscript['gTransStart'];
-                            $aTranscript['chromTransEnd'] = $aTranscript['gTransEnd'];
-                        }
+                        $aSQL = array(
+                            'geneid' => $aGenes[$aVariant['symbol']]['id'],
+                            'name' => $aTranscript['name'],
+                            'id_ncbi' => $sTranscript,
+                            'id_protein_ncbi' => ($aTranscript['id_ncbi_protein'] ?? ''),
+                            'position_g_mrna_start' => ($aTranscript['genomic_positions'][$_CONF['refseq_build']][$aVariant['chromosome']]['start'] ?? 0),
+                            'position_g_mrna_end' => ($aTranscript['genomic_positions'][$_CONF['refseq_build']][$aVariant['chromosome']]['end'] ?? 0),
+                            'position_c_mrna_start' => -$aTranscript['transcript_positions']['cds_start'] + 1,
+                            'position_c_mrna_end' => $aTranscript['transcript_positions']['length'] - $aTranscript['transcript_positions']['cds_start'] + 1,
+                            'position_c_cds_end' => ($aTranscript['transcript_positions']['cds_length'] ?: 0),
+                        );
 
                         // Add transcript to gene.
-                        if (!$_DB->q('INSERT INTO ' . TABLE_TRANSCRIPTS . '
-                             (id, geneid, name, id_ncbi, id_ensembl, id_protein_ncbi, id_protein_ensembl, id_protein_uniprot, remarks, position_c_mrna_start, position_c_mrna_end, position_c_cds_end, position_g_mrna_start, position_g_mrna_end, created_date, created_by)
-                            VALUES (NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), ?)',
-                            array($aGenes[$aVariant['symbol']]['id'], $sTranscriptName, $aTranscript['id_ncbi'], '', $sTranscriptProtein, '', '', '', $aTranscript['cTransStart'], $aTranscript['sortableTransEnd'], $aTranscript['cCDSStop'], $aTranscript['chromTransStart'], $aTranscript['chromTransEnd'], 0))) {
-                            $sMessage = 'Can\'t create transcript ' . $aTranscript['id_ncbi'] . ' for gene ' . $aVariant['symbol'] . '.';
+                        if (!$_DB->q('
+                            INSERT INTO ' . TABLE_TRANSCRIPTS . '
+                              (id, ' . implode(', ', array_keys($aSQL)) . ', created_date, created_by)
+                            VALUES (NULL, ' . str_repeat('?, ', count($aSQL)) . 'NOW(), 0)',
+                            array_values($aSQL))
+                        ) {
+                            $sMessage = 'Can\'t create transcript ' . $sTranscript . ' for gene ' . $aVariant['symbol'] . '.';
                             lovd_printIfVerbose(VERBOSITY_LOW, $sMessage . "\n");
                             lovd_handleAnnotationError($aVariant, $sMessage);
                         }
@@ -801,12 +800,12 @@ foreach ($aFiles as $sFileID) {
                         $nTranscriptID = str_pad($_DB->lastInsertId(), $_SETT['objectid_length']['transcripts'], '0', STR_PAD_LEFT);
 
                         // Write to log...
-                        lovd_writeLog('Event', LOG_EVENT, 'Transcript entry successfully added to gene ' . $aGenes[$aVariant['symbol']]['id'] . ' - ' . $sTranscriptName);
-                        lovd_printIfVerbose(VERBOSITY_MEDIUM, 'Created transcript ' . $aTranscript['id'] . ".\n");
+                        lovd_writeLog('Event', LOG_EVENT, 'Transcript entry successfully added to gene ' . $aGenes[$aVariant['symbol']]['id'] . ' - ' . $sTranscript);
+                        lovd_printIfVerbose(VERBOSITY_MEDIUM, 'Created transcript ' . $sTranscript . ".\n");
                         flush();
 
                         // Store in memory.
-                        $aTranscripts[$aVariant['id_ncbi']] = array_merge($aTranscript, array('id' => $nTranscriptID)); // Contains a lot more info than needed, but whatever.
+                        $aTranscripts[$aVariant['id_ncbi']] = array_merge(array('id' => $nTranscriptID), $aTranscript); // Contains a lot more info than needed, but whatever.
                     }
                 }
 
@@ -817,8 +816,8 @@ foreach ($aFiles as $sFileID) {
             }
         }
         // We created the transcript if possible, but we might still not have it.
-        // $aVariant['id_ncbi']                                // How we received the transcript from VEP.
-        // $aTranscripts[$aVariant['id_ncbi']]['id_ncbi']      // The NCBI ID of the transcript in the database (can be different version).
+        // $aVariant['id_ncbi']                // How we received the transcript from VEP.
+        // $aTranscripts[$aVariant['id_ncbi']] // The rest of the transcript information, from the database.
 
         // Store transcript ID without version, we'll use it plenty of times.
         $aLine['transcript_noversion'] = strstr($aVariant['id_ncbi'], '.', true);

--- a/src/scripts/convert_and_merge_data_files.php
+++ b/src/scripts/convert_and_merge_data_files.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2014-11-28
- * Modified    : 2022-12-09
- * For LOVD+   : 3.0-29
+ * Modified    : 2025-07-15
+ * For LOVD+   : 3.0-30
  *
- * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2025 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Anthony Marty <anthony.marty@unimelb.edu.au>
  *               Juny Kesumadewi <juny.kesumadewi@unimelb.edu.au>
@@ -28,6 +28,7 @@ $_SERVER = array_merge($_SERVER, array(
 ));
 require ROOT_PATH . 'inc-init.php';
 require ROOT_PATH . 'inc-lib-genes.php';
+require ROOT_PATH . 'libs/HGVS-syntax-checker/HGVS.php';
 // This script is optimized for speed, not memory usage. As such, it can use quite a lot of memory, but it's as fast as
 // we can make it. Loading all the gene and transcript data uses quite a lot of memory. An top of that, if the input
 // file is very large (unfiltered VCFs, for instance), this script can halt without warning.
@@ -211,114 +212,6 @@ function lovd_handleAnnotationError (&$aVariant, $sErrorMsg)
     }
 
     return $nAnnotationErrors;
-}
-
-
-
-
-
-function lovd_getVariantDescription (&$aVariant, $sRef, $sAlt)
-{
-    // Constructs a variant description from $sRef and $sAlt and adds it to $aVariant in a new 'VariantOnGenome/DNA' key.
-    // The 'position_g_start' and 'position_g_end' keys in $aVariant are adjusted accordingly and a 'type' key is added too.
-    // The numbering scheme is either g. or m. and depends on the 'chromosome' key in $aVariant.
-    // Requires:
-    //   $aVariant['chromosome']
-    //   $aVariant['position']
-    // Adds:
-    //   $aVariant['position_g_start']
-    //   $aVariant['position_g_end']
-    //   $aVariant['type']
-    //   $aVariant['VariantOnGenome/DNA']
-
-    // Make all bases uppercase.
-    $sRef = strtoupper($sRef);
-    $sAlt = strtoupper($sAlt);
-
-    // Clear out empty REF and ALTs. This is not allowed in the VCF specs,
-    //  but some tools create them nonetheless.
-    foreach (array('sRef', 'sAlt') as $var) {
-        if (in_array($$var, array('.', '-'))) {
-            $$var = '';
-        }
-    }
-
-    // Use the right prefix for the numbering scheme.
-    $sHGVSPrefix = 'g.';
-    if ($aVariant['chromosome'] == 'M') {
-        $sHGVSPrefix = 'm.';
-    }
-
-    // Even substitutions are sometimes mentioned as longer Refs and Alts, so we'll always need to isolate the actual difference.
-    $aVariant['position_g_start'] = $aVariant['position'];
-    $aVariant['position_g_end'] = $aVariant['position'] + strlen($sRef) - 1;
-
-    // Save original values before we edit them.
-    $sRefOriginal = $sRef;
-    $sAltOriginal = $sAlt;
-
-    // 'Eat' letters from either end - first left, then right - to isolate the difference.
-    while (strlen($sRef) > 0 && strlen($sAlt) > 0 && $sRef[0] == $sAlt[0]) {
-        $sRef = substr($sRef, 1);
-        $sAlt = substr($sAlt, 1);
-        $aVariant['position_g_start'] ++;
-    }
-    while (strlen($sRef) > 0 && strlen($sAlt) > 0 && $sRef[strlen($sRef) - 1] == $sAlt[strlen($sAlt) - 1]) {
-        $sRef = substr($sRef, 0, -1);
-        $sAlt = substr($sAlt, 0, -1);
-        $aVariant['position_g_end'] --;
-    }
-
-    // Substitution, or something else?
-    if (strlen($sRef) == 1 && strlen($sAlt) == 1) {
-        // Substitutions.
-        $aVariant['type'] = 'subst';
-        $aVariant['VariantOnGenome/DNA'] = $sHGVSPrefix . $aVariant['position_g_start'] . $sRef . '>' . $sAlt;
-    } else {
-        // Insertions/duplications, deletions, inversions, indels.
-
-        // Now find out the variant type.
-        if (strlen($sRef) > 0 && strlen($sAlt) == 0) {
-            // Deletion.
-            $aVariant['type'] = 'del';
-            if ($aVariant['position_g_start'] == $aVariant['position_g_end']) {
-                $aVariant['VariantOnGenome/DNA'] = $sHGVSPrefix . $aVariant['position_g_start'] . 'del';
-            } else {
-                $aVariant['VariantOnGenome/DNA'] = $sHGVSPrefix . $aVariant['position_g_start'] . '_' . $aVariant['position_g_end'] . 'del';
-            }
-        } elseif (strlen($sAlt) > 0 && strlen($sRef) == 0) {
-            // Something has been added... could be an insertion or a duplication.
-            if ($sRefOriginal && substr($sAltOriginal, strrpos($sAltOriginal, $sAlt) - strlen($sAlt), strlen($sAlt)) == $sAlt) {
-                // Duplicaton (not allowed when REF was empty from the start).
-                $aVariant['type'] = 'dup';
-                $aVariant['position_g_start'] -= strlen($sAlt);
-                if ($aVariant['position_g_start'] == $aVariant['position_g_end']) {
-                    $aVariant['VariantOnGenome/DNA'] = $sHGVSPrefix . $aVariant['position_g_start'] . 'dup';
-                } else {
-                    $aVariant['VariantOnGenome/DNA'] = $sHGVSPrefix . $aVariant['position_g_start'] . '_' . $aVariant['position_g_end'] . 'dup';
-                }
-            } else {
-                // Insertion.
-                $aVariant['type'] = 'ins';
-                // Exchange g_start and g_end; after the 'letter eating' we did, start is actually end + 1!
-                $aVariant['position_g_start'] --;
-                $aVariant['position_g_end'] ++;
-                $aVariant['VariantOnGenome/DNA'] = $sHGVSPrefix . $aVariant['position_g_start'] . '_' . $aVariant['position_g_end'] . 'ins' . $sAlt;
-            }
-        } elseif ($sRef == strrev(str_replace(array('a', 'c', 'g', 't'), array('T', 'G', 'C', 'A'), strtolower($sAlt)))) {
-            // Inversion.
-            $aVariant['type'] = 'inv';
-            $aVariant['VariantOnGenome/DNA'] = $sHGVSPrefix . $aVariant['position_g_start'] . '_' . $aVariant['position_g_end'] . 'inv';
-        } else {
-            // Deletion/insertion.
-            $aVariant['type'] = 'delins';
-            if ($aVariant['position_g_start'] == $aVariant['position_g_end']) {
-                $aVariant['VariantOnGenome/DNA'] = $sHGVSPrefix . $aVariant['position_g_start'] . 'delins' . $sAlt;
-            } else {
-                $aVariant['VariantOnGenome/DNA'] = $sHGVSPrefix . $aVariant['position_g_start'] . '_' . $aVariant['position_g_end'] . 'delins' . $sAlt;
-            }
-        }
-    }
 }
 
 
@@ -626,8 +519,21 @@ foreach ($aFiles as $sFileID) {
         // First, VOG fields.
         // Chromosome.
         $aVariant['chromosome'] = substr($aVariant['chromosome'], 3); // chr1 -> 1
-        // VOG/DNA and the position fields.
-        lovd_getVariantDescription($aVariant, $aVariant['ref'], $aVariant['alt']);
+
+        // VOG/DNA and the position fields. Use the new HGVS syntax checker for this.
+        $HGVS = HGVS_VCF::check(
+            $_CONF['refseq_build'] .
+            ':' . $aVariant['chromosome'] .
+            ':' . $aVariant['position'] .
+            ':' . $aVariant['ref'] .
+            ':' . $aVariant['alt']
+        );
+        $aVariantInfo = $HGVS->getInfo();
+        $aVariant['position_g_start'] = ($aVariantInfo['data']['position_start'] ?? 0);
+        $aVariant['position_g_end'] = ($aVariantInfo['data']['position_end'] ?? 0);
+        $aVariant['type'] = ($aVariantInfo['data']['type'] ?? '');
+        $aVariant['VariantOnGenome/DNA'] = array_key_first($aVariantInfo['corrected_values'] ?? []);
+
         // dbSNP.
         if (!empty($aVariant['VariantOnGenome/dbSNP'])
             && (strpos($aVariant['VariantOnGenome/dbSNP'], ';') !== false
@@ -644,6 +550,7 @@ foreach ($aFiles as $sFileID) {
                 }
             }
         }
+
         // Fixing some other VOG fields.
         foreach (array('VariantOnGenome/Sequencing/Father/GenoType', 'VariantOnGenome/Sequencing/Father/GenoType/Quality', 'VariantOnGenome/Sequencing/Mother/GenoType', 'VariantOnGenome/Sequencing/Mother/GenoType/Quality') as $sCol) {
             if (!empty($aVariant[$sCol]) && $aVariant[$sCol] == 'None') {

--- a/src/scripts/convert_and_merge_data_files.php
+++ b/src/scripts/convert_and_merge_data_files.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2014-11-28
- * Modified    : 2025-07-15
+ * Modified    : 2025-07-16
  * For LOVD+   : 3.0-30
  *
  * Copyright   : 2004-2025 Leiden University Medical Center; http://www.LUMC.nl/
@@ -433,7 +433,7 @@ foreach ($aFiles as $sFileID) {
     $nAnnotationErrors = 0; // Count the number of lines we cannot import.
 
     // Get all the existing genes in one database call.
-    $aGenes = $_DB->q('SELECT id, id, name FROM ' . TABLE_GENES)->fetchAllGroupAssoc();
+    $aGenes = $_DB->q('SELECT id, id, id_hgnc, name FROM ' . TABLE_GENES)->fetchAllGroupAssoc();
 
     // If we're receiving the HGNC ID, we'll collect all genes for their HGNC IDs as well. This will be used to help
     //  LOVD+ to handle changed gene symbols.
@@ -643,7 +643,7 @@ foreach ($aFiles as $sFileID) {
             && (!preg_match('/^LOC[0-9]+$/', $aVariant['symbol']) || empty($_INSTANCE_CONFIG['conversion']['use_hgnc']) || empty($_INSTANCE_CONFIG['conversion']['enforce_hgnc_gene']))) {
             // First try to get this gene from the database, perhaps conversions run in parallel have created it now.
             // FIXME: This is duplicated code. Make it into a function, perhaps?
-            if ($aGene = $_DB->q('SELECT g.id, g.name FROM ' . TABLE_GENES . ' AS g WHERE g.id = ?', array($aVariant['symbol']))->fetchAssoc()) {
+            if ($aGene = $_DB->q('SELECT g.id, g.id_hgnc, g.name FROM ' . TABLE_GENES . ' AS g WHERE g.id = ?', array($aVariant['symbol']))->fetchAssoc()) {
                 // We've got it in the database.
                 $aGenes[$aVariant['symbol']] = $aGene;
 
@@ -679,7 +679,7 @@ foreach ($aFiles as $sFileID) {
                         // Detect alias, and store these for next run.
                         lovd_printIfVerbose(VERBOSITY_MEDIUM, '\'' . $aVariant['symbol'] . '\' => \'' . $aGeneInfo['symbol'] . '\',' . "\n");
                         // FIXME: This is duplicated code. Make it into a function, perhaps?
-                        if ($aGene = $_DB->q('SELECT g.id, g.name FROM ' . TABLE_GENES . ' AS g WHERE g.id = ?', array($aGeneInfo['symbol']))->fetchAssoc()) {
+                        if ($aGene = $_DB->q('SELECT g.id, g.id_hgnc, g.name FROM ' . TABLE_GENES . ' AS g WHERE g.id = ?', array($aGeneInfo['symbol']))->fetchAssoc()) {
                             // We've got the alias already in the database; store it under the symbol we're using so that we'll find it back easily.
                             $aGenes[$aVariant['symbol']] = $aGene;
                         }
@@ -705,9 +705,9 @@ foreach ($aFiles as $sFileID) {
 
                     // Create the gene, with whatever info we have.
                     if (!$_DB->q('INSERT INTO ' . TABLE_GENES . '
-                        (id, name, chromosome, chrom_band, refseq_genomic, refseq_UD, reference, url_homepage, url_external, allow_download, id_hgnc, id_entrez, id_omim, show_hgmd, show_genecards, show_genetests, note_index, note_listing, refseq, refseq_url, disclaimer, disclaimer_text, header, header_align, footer, footer_align, created_by, created_date, updated_by, updated_date)
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), ?, NOW())',
-                        array($aGeneInfo['symbol'], $aGeneInfo['name'], $aGeneInfo['chromosome'], $aGeneInfo['chrom_band'], $_SETT['human_builds'][$_CONF['refseq_build']]['ncbi_sequences'][$aGeneInfo['chromosome']], '', '', '', '', 0, $aGeneInfo['hgnc_id'], $aGeneInfo['entrez_id'], (!$aGeneInfo['omim_id']? NULL : $aGeneInfo['omim_id']), 0, 0, 0, '', '', '', '', 0, '', '', 0, '', 0, 0, 0))
+                          (id, name, chromosome, chrom_band, refseq_genomic, id_hgnc, id_entrez, id_omim, disclaimer, created_by, created_date, updated_by, updated_date)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NOW(), 0, NOW())',
+                        array($aGeneInfo['symbol'], $aGeneInfo['name'], $aGeneInfo['chromosome'], $aGeneInfo['chrom_band'], $_SETT['human_builds'][$_CONF['refseq_build']]['ncbi_sequences'][$aGeneInfo['chromosome']], $aGeneInfo['hgnc_id'], $aGeneInfo['entrez_id'], (!$aGeneInfo['omim_id']? NULL : $aGeneInfo['omim_id']), 0))
                     ) {
                         $sMessage = 'Can\'t create gene ' . $aVariant['symbol'] . '.';
                         lovd_printIfVerbose(VERBOSITY_LOW, $sMessage . "\n");
@@ -723,7 +723,7 @@ foreach ($aFiles as $sFileID) {
                     flush();
 
                     // Store this gene, again under the original symbol, so we can easily find it back.
-                    $aGenes[$aVariant['symbol']] = array('id' => $aGeneInfo['symbol'], 'name' => $aGeneInfo['name']);
+                    $aGenes[$aVariant['symbol']] = array('id' => $aGeneInfo['symbol'], 'id_hgnc' => $aGeneInfo['hgnc_id'], 'name' => $aGeneInfo['name']);
                 }
             }
         }

--- a/src/scripts/convert_and_merge_data_files.php
+++ b/src/scripts/convert_and_merge_data_files.php
@@ -29,6 +29,8 @@ $_SERVER = array_merge($_SERVER, array(
 require ROOT_PATH . 'inc-init.php';
 require ROOT_PATH . 'inc-lib-genes.php';
 require ROOT_PATH . 'libs/HGVS-syntax-checker/HGVS.php';
+require ROOT_PATH . 'libs/HGVS-syntax-checker/variant_validator.php';
+$_VV = new LOVD_VV();
 // This script is optimized for speed, not memory usage. As such, it can use quite a lot of memory, but it's as fast as
 // we can make it. Loading all the gene and transcript data uses quite a lot of memory. An top of that, if the input
 // file is very large (unfiltered VCFs, for instance), this script can halt without warning.
@@ -59,16 +61,6 @@ if ($_CONF['proxy_host']) {
 }
 if (!empty($_CONF['proxy_username']) && !empty($_CONF['proxy_password'])) {
     curl_setopt($ch, CURLOPT_PROXYUSERPWD, $_CONF['proxy_username'] . ':' . $_CONF['proxy_password']);
-}
-
-function mutalyzer_getTranscriptsAndInfo ($ref, $gene)
-{
-    global $ch, $_CONF;
-
-    $sUrl = str_replace('/services', '', $_CONF['mutalyzer_soap_url']) . '/json/getTranscriptsAndInfo?genomicReference=' . $ref . '&geneName=' . $gene;
-    curl_setopt($ch, CURLOPT_URL, $sUrl);
-
-    return curl_exec($ch);
 }
 
 function mutalyzer_numberConversion ($build, $variant)
@@ -734,81 +726,46 @@ foreach ($aFiles as $sFileID) {
 
 
 
-        // Store transcript ID without version, we'll use it plenty of times.
-        $aLine['transcript_noversion'] = substr($aVariant['id_ncbi'], 0, strpos($aVariant['id_ncbi'] . '.', '.')+1);
-        if (empty($aVariant['symbol']) || !isset($aGenes[$aVariant['symbol']]) || !$aGenes[$aVariant['symbol']]) {
+        if (empty($aVariant['symbol']) || empty($aGenes[$aVariant['symbol']])) {
             // We really couldn't do anything with this gene (now, or last time).
             $aGenes[$aVariant['symbol']] = false;
 
         } elseif (!empty($aVariant['id_ncbi']) && !isset($aTranscripts[$aVariant['id_ncbi']])) {
             // Gene found, transcript given but not yet seen before. Get transcript information.
-            // We could loop through $aTranscripts to look for the NCBI ID with a different version, but since a
-            //  different process might have created this transcript and therefore we prefer checking the database,
-            //  we might as well rely on that completely.
-            // Try to get this transcript from the database, ignoring (but preferring) version.
-            // When not having a match on the version, we prefer the transcript most recently created.
-            if ($aTranscript = $_DB->q('SELECT id, geneid, id_ncbi, position_c_cds_end, position_g_mrna_start, position_g_mrna_end FROM ' . TABLE_TRANSCRIPTS . ' WHERE id_ncbi LIKE ? ORDER BY (id_ncbi = ?) DESC, id DESC LIMIT 1', array($aLine['transcript_noversion'] . '%', $aVariant['id_ncbi']))->fetchAssoc()) {
+            // We could loop through $aTranscripts to look for the NCBI ID, but since a different process might have
+            //  created this transcript, we prefer checking the database, we might as well rely on that completely.
+            // We used to ignore the transcript version here, but we no longer do that.
+            if ($aTranscript = $_DB->q('SELECT id, geneid, id_ncbi, position_c_cds_end, position_g_mrna_start, position_g_mrna_end FROM ' . TABLE_TRANSCRIPTS . ' WHERE id_ncbi = ?', array($aVariant['id_ncbi']))->fetchAssoc()) {
                 // We've got it in the database.
                 $aTranscripts[$aVariant['id_ncbi']] = $aTranscript;
 
             } elseif (!empty($_INSTANCE_CONFIG['conversion']['create_genes_and_transcripts'])) {
                 // To prevent us from having to check the available transcripts all the time, we store the available transcripts, but only insert those we need.
-                if (isset($aGenes[$aVariant['symbol']]['transcripts_in_NC'])) {
-                    $aTranscriptInfo = $aGenes[$aVariant['symbol']]['transcripts_in_NC'];
+                if (isset($aGenes[$aVariant['symbol']]['available_transcripts'])) {
+                    $aTranscriptInfo = $aGenes[$aVariant['symbol']]['available_transcripts'];
 
                 } else {
-                    $aTranscriptInfo = array();
                     lovd_printIfVerbose(VERBOSITY_HIGH, 'Loading transcript information for ' . $aGenes[$aVariant['symbol']]['id'] . '...' . "\n");
-                    $nSleepTime = 2;
-                    // Since we're using the NC as a source now, try multiple gene symbols to use.
-                    // Genes can change, and we're not 100% sure about which gene symbol is in the NC.
-                    // Start with the one we have in the database, then our alias, then the VEP one.
-                    // (note that we could retrieve the entire chromosome's list of transcripts, but that'll be slow)
-                    $aGenesToTry = array_unique(array($aGenes[$aVariant['symbol']]['id'], $aVariant['symbol'], $aVariant['symbol_vep']));
-                    foreach ($aGenesToTry as $sGeneToTry) {
-                        // Retry Mutalyzer call several times until successful.
-                        $sJSONResponse = false;
-                        for ($i = 0; $i <= $nMutalyzerRetries; $i++) {
-                            $aMutalyzerCalls['getTranscriptsAndInfo']++;
-                            $tMutalyzerStart = microtime(true);
-                            $sJSONResponse = mutalyzer_getTranscriptsAndInfo($_SETT['human_builds'][$_CONF['refseq_build']]['ncbi_sequences'][$aVariant['chromosome']], $sGeneToTry);
-                            $tMutalyzerCalls += (microtime(true) - $tMutalyzerStart);
-                            $nMutalyzer++;
-                            if ($sJSONResponse === false) {
-                                // The Mutalyzer call has failed.
-                                sleep($nSleepTime); // Sleep for some time.
-                                $nSleepTime = $nSleepTime * 2; // Double the amount of time that we sleep each time.
-                            } else {
-                                break;
-                            }
-                        }
-                        if ($sJSONResponse === false) {
-                            lovd_printIfVerbose(VERBOSITY_LOW, '>>>>> Attempted to call Mutalyzer ' . $nMutalyzerRetries . ' times to getTranscriptsAndInfo and failed on line ' . $nLine . '.' . "\n");
 
-                        } elseif ($aResponse = json_decode($sJSONResponse, true)) {
-                            // Before we had to go two layers deep; through the result, then read out the info.
-                            // But now apparently this service just returns the string with quotes (the latter are removed by json_decode()).
-                            $aTranscriptInfo = $aResponse;
+                    // Fetch the transcripts using the HGNC ID, so we won't have issues with gene symbols.
+                    $tMutalyzerStart = microtime(true);
+                    $aTranscriptInfo = $_VV->getTranscriptsByID('HGNC:' . $aGenes[$aVariant['symbol']]['id_hgnc']);
+                    $tMutalyzerCalls += (microtime(true) - $tMutalyzerStart);
+                    $aMutalyzerCalls['getTranscriptsAndInfo']++;
+                    $nMutalyzer++;
 
-                            if (empty($aTranscriptInfo) || !is_array($aTranscriptInfo) || !empty($aTranscriptInfo['faultcode'])) {
-                                if (!empty($aTranscriptInfo['faultcode'])) {
-                                    // Something went wrong. Let the user know.
-                                    lovd_printIfVerbose(VERBOSITY_MEDIUM, 'Error while retrieving transcripts for gene ' . $aGenes[$aVariant['symbol']]['id'] . ' (' . $aTranscriptInfo['faultcode'] . '): ' . $aTranscriptInfo['faultstring'] . '.' . "\n");
-                                } else {
-                                    // Usually this is the case. Not always an error.
-                                    lovd_printIfVerbose(VERBOSITY_MEDIUM, 'No available transcripts for gene ' . $aGenes[$aVariant['symbol']]['id'] . ' found.' . "\n");
-                                }
-                                $aTranscripts[$aVariant['id_ncbi']] = false; // Ignore transcript.
-                                $aTranscriptInfo = array(array('id' => 'NO_TRANSCRIPTS')); // Basically, any text will do. Just stop searching for other transcripts for this gene.
-                            } else {
-                                // Found transcripts. Don't look for any other gene. Use the $aTranscriptInfo that we have.
-                                break;
-                            }
-                        }
+                    if (!$aTranscriptInfo || !empty($aTranscriptInfo['errors'])) {
+                        // Something went wrong. Let the user know.
+                        lovd_printIfVerbose(VERBOSITY_MEDIUM, 'Error while retrieving transcripts for gene ' . $aGenes[$aVariant['symbol']]['id'] . ': ' . implode('; ', $aTranscriptInfo['errors']) . '.' . "\n");
+
+                    } elseif (empty($aTranscriptInfo['data'])) {
+                        // No results, unfortunately.
+                        lovd_printIfVerbose(VERBOSITY_MEDIUM, 'No available transcripts for gene ' . $aGenes[$aVariant['symbol']]['id'] . ' found.' . "\n");
                     }
 
                     // Store for next time.
-                    $aGenes[$aVariant['symbol']]['transcripts_in_NC'] = $aTranscriptInfo;
+                    $aTranscriptInfo = ($aTranscriptInfo['data'] ?? []);
+                    $aGenes[$aVariant['symbol']]['available_transcripts'] = $aTranscriptInfo;
                 }
 
                 // Loop transcript options, add the one we need.
@@ -863,6 +820,8 @@ foreach ($aFiles as $sFileID) {
         // $aVariant['id_ncbi']                                // How we received the transcript from VEP.
         // $aTranscripts[$aVariant['id_ncbi']]['id_ncbi']      // The NCBI ID of the transcript in the database (can be different version).
 
+        // Store transcript ID without version, we'll use it plenty of times.
+        $aLine['transcript_noversion'] = strstr($aVariant['id_ncbi'], '.', true);
         // Now check, if we managed to get the transcript ID. If not, then we'll have to continue without it.
         if (empty($aVariant['id_ncbi']) || $_ADAPTER->ignoreTranscript($aVariant['id_ncbi']) || empty($aTranscripts[$aVariant['id_ncbi']])) {
             // When the transcript still doesn't exist, or it evaluates to false (we don't have it, we can't get it), then skip it.

--- a/src/scripts/convert_and_merge_data_files.php
+++ b/src/scripts/convert_and_merge_data_files.php
@@ -635,10 +635,11 @@ foreach ($aFiles as $sFileID) {
                 $aGeneAliases[$aVariant['symbol_vep']] = $aVariant['symbol'];
             }
         }
+
         // Verify gene exists, and create it if needed.
         // LOC* genes always fail here, so those we don't try unless we don't care about the HGNC.
         // Also, don't do anything if we're ignoring the transcript - what good will it do?
-        if (!empty($aVariant['symbol']) && !isset($aGenes[$aVariant['symbol']]) && !in_array($aVariant['symbol'], $aGenesToIgnore) && !$_ADAPTER->ignoreTranscript($aVariant['transcriptid'])
+        if (!empty($aVariant['symbol']) && !isset($aGenes[$aVariant['symbol']]) && !in_array($aVariant['symbol'], $aGenesToIgnore) && !$_ADAPTER->ignoreTranscript($aVariant['id_ncbi'])
             && (!preg_match('/^LOC[0-9]+$/', $aVariant['symbol']) || empty($_INSTANCE_CONFIG['conversion']['use_hgnc']) || empty($_INSTANCE_CONFIG['conversion']['enforce_hgnc_gene']))) {
             // First try to get this gene from the database, perhaps conversions run in parallel have created it now.
             // FIXME: This is duplicated code. Make it into a function, perhaps?
@@ -734,22 +735,21 @@ foreach ($aFiles as $sFileID) {
 
 
         // Store transcript ID without version, we'll use it plenty of times.
-        // FIXME: Using 'transcriptid' for the NCBI ID is confusing. Better map it to 'id_ncbi'? (check everywhere)
-        $aLine['transcript_noversion'] = substr($aVariant['transcriptid'], 0, strpos($aVariant['transcriptid'] . '.', '.')+1);
+        $aLine['transcript_noversion'] = substr($aVariant['id_ncbi'], 0, strpos($aVariant['id_ncbi'] . '.', '.')+1);
         if (empty($aVariant['symbol']) || !isset($aGenes[$aVariant['symbol']]) || !$aGenes[$aVariant['symbol']]) {
             // We really couldn't do anything with this gene (now, or last time).
             $aGenes[$aVariant['symbol']] = false;
 
-        } elseif (!empty($aVariant['transcriptid']) && !isset($aTranscripts[$aVariant['transcriptid']])) {
+        } elseif (!empty($aVariant['id_ncbi']) && !isset($aTranscripts[$aVariant['id_ncbi']])) {
             // Gene found, transcript given but not yet seen before. Get transcript information.
             // We could loop through $aTranscripts to look for the NCBI ID with a different version, but since a
             //  different process might have created this transcript and therefore we prefer checking the database,
             //  we might as well rely on that completely.
             // Try to get this transcript from the database, ignoring (but preferring) version.
             // When not having a match on the version, we prefer the transcript most recently created.
-            if ($aTranscript = $_DB->q('SELECT id, geneid, id_ncbi, position_c_cds_end, position_g_mrna_start, position_g_mrna_end FROM ' . TABLE_TRANSCRIPTS . ' WHERE id_ncbi LIKE ? ORDER BY (id_ncbi = ?) DESC, id DESC LIMIT 1', array($aLine['transcript_noversion'] . '%', $aVariant['transcriptid']))->fetchAssoc()) {
+            if ($aTranscript = $_DB->q('SELECT id, geneid, id_ncbi, position_c_cds_end, position_g_mrna_start, position_g_mrna_end FROM ' . TABLE_TRANSCRIPTS . ' WHERE id_ncbi LIKE ? ORDER BY (id_ncbi = ?) DESC, id DESC LIMIT 1', array($aLine['transcript_noversion'] . '%', $aVariant['id_ncbi']))->fetchAssoc()) {
                 // We've got it in the database.
-                $aTranscripts[$aVariant['transcriptid']] = $aTranscript;
+                $aTranscripts[$aVariant['id_ncbi']] = $aTranscript;
 
             } elseif (!empty($_INSTANCE_CONFIG['conversion']['create_genes_and_transcripts'])) {
                 // To prevent us from having to check the available transcripts all the time, we store the available transcripts, but only insert those we need.
@@ -798,7 +798,7 @@ foreach ($aFiles as $sFileID) {
                                     // Usually this is the case. Not always an error.
                                     lovd_printIfVerbose(VERBOSITY_MEDIUM, 'No available transcripts for gene ' . $aGenes[$aVariant['symbol']]['id'] . ' found.' . "\n");
                                 }
-                                $aTranscripts[$aVariant['transcriptid']] = false; // Ignore transcript.
+                                $aTranscripts[$aVariant['id_ncbi']] = false; // Ignore transcript.
                                 $aTranscriptInfo = array(array('id' => 'NO_TRANSCRIPTS')); // Basically, any text will do. Just stop searching for other transcripts for this gene.
                             } else {
                                 // Found transcripts. Don't look for any other gene. Use the $aTranscriptInfo that we have.
@@ -849,24 +849,24 @@ foreach ($aFiles as $sFileID) {
                         flush();
 
                         // Store in memory.
-                        $aTranscripts[$aVariant['transcriptid']] = array_merge($aTranscript, array('id' => $nTranscriptID)); // Contains a lot more info than needed, but whatever.
+                        $aTranscripts[$aVariant['id_ncbi']] = array_merge($aTranscript, array('id' => $nTranscriptID)); // Contains a lot more info than needed, but whatever.
                     }
                 }
 
-                if (!isset($aTranscripts[$aVariant['transcriptid']])) {
+                if (!isset($aTranscripts[$aVariant['id_ncbi']])) {
                     // We don't have it, we can't get it... Stop looking for it, please!
-                    $aTranscripts[$aVariant['transcriptid']] = false;
+                    $aTranscripts[$aVariant['id_ncbi']] = false;
                 }
             }
         }
         // We created the transcript if possible, but we might still not have it.
-        // $aVariant['transcriptid']                           // How we received the transcript from VEP.
-        // $aTranscripts[$aVariant['transcriptid']]['id_ncbi'] // The NCBI ID of the transcript in the database (can be different version).
+        // $aVariant['id_ncbi']                                // How we received the transcript from VEP.
+        // $aTranscripts[$aVariant['id_ncbi']]['id_ncbi']      // The NCBI ID of the transcript in the database (can be different version).
 
         // Now check, if we managed to get the transcript ID. If not, then we'll have to continue without it.
-        if (empty($aVariant['transcriptid']) || $_ADAPTER->ignoreTranscript($aVariant['transcriptid']) || empty($aTranscripts[$aVariant['transcriptid']])) {
+        if (empty($aVariant['id_ncbi']) || $_ADAPTER->ignoreTranscript($aVariant['id_ncbi']) || empty($aTranscripts[$aVariant['id_ncbi']])) {
             // When the transcript still doesn't exist, or it evaluates to false (we don't have it, we can't get it), then skip it.
-            $aVariant['transcriptid'] = '';
+            $aVariant['id_ncbi'] = '';
         } else { // We'll handle this transcript.
             // Handle the rest of the VOT columns.
             // First, take off the transcript name, so we can easily check for a del/ins checking for an underscore.
@@ -927,12 +927,12 @@ foreach ($aFiles as $sFileID) {
                 }
 
                 // Find mapping of variant on the currently handled transcript.
-                if (isset($aMappings[$aTranscripts[$aVariant['transcriptid']]['id_ncbi']])) {
+                if (isset($aMappings[$aTranscripts[$aVariant['id_ncbi']]['id_ncbi']])) {
                     // Successfully mapped on the transcript version that we have in the database.
-                    $aVariant['VariantOnTranscript/DNA'] = $aMappings[$aTranscripts[$aVariant['transcriptid']]['id_ncbi']];
-                } elseif (isset($aMappings[$aVariant['transcriptid']])) {
+                    $aVariant['VariantOnTranscript/DNA'] = $aMappings[$aTranscripts[$aVariant['id_ncbi']]['id_ncbi']];
+                } elseif (isset($aMappings[$aVariant['id_ncbi']])) {
                     // Successfully mapped on the transcript version received by VEP.
-                    $aVariant['VariantOnTranscript/DNA'] = $aMappings[$aVariant['transcriptid']];
+                    $aVariant['VariantOnTranscript/DNA'] = $aMappings[$aVariant['id_ncbi']];
                 } else {
                     // Somehow, we can't find the transcript in the mapping info.
                     // This can only happen either when the NC has a different transcript than the one we have in the
@@ -946,7 +946,7 @@ foreach ($aFiles as $sFileID) {
                         }
                     }
                     if ($aAlternativeVersions) {
-                        lovd_printIfVerbose(VERBOSITY_FULL, 'Found alternative by searching: ' . $aVariant['transcriptid'] . ' [' . implode(', ', $aAlternativeVersions) . ']' . "\n");
+                        lovd_printIfVerbose(VERBOSITY_FULL, 'Found alternative by searching: ' . $aVariant['id_ncbi'] . ' [' . implode(', ', $aAlternativeVersions) . ']' . "\n");
                         $aVariant['VariantOnTranscript/DNA'] = $aMappings[$aAlternativeVersions[0]];
                     } else {
                         // This happens when VEP says we can map on a known transcript, but doesn't provide us a valid mapping,
@@ -1011,8 +1011,8 @@ foreach ($aFiles as $sFileID) {
                                     krsort($aMutalyzerMappings);
                                     $sTranscriptName = '';
                                     // First check if we have the exact right version for it.
-                                    if (isset($aMutalyzerMappings[substr(strrchr($aVariant['transcriptid'], '.'), 1)])) {
-                                        $sTranscriptName = $aMutalyzerMappings[substr($aVariant['transcriptid'], strlen($aLine['transcript_noversion']))];
+                                    if (isset($aMutalyzerMappings[substr(strrchr($aVariant['id_ncbi'], '.'), 1)])) {
+                                        $sTranscriptName = $aMutalyzerMappings[substr($aVariant['id_ncbi'], strlen($aLine['transcript_noversion']))];
                                     } else {
                                         $sTranscriptName = current($aMutalyzerMappings);
                                     }
@@ -1049,7 +1049,7 @@ foreach ($aFiles as $sFileID) {
             //  c. variants.
             $aVariantInfo = lovd_getVariantInfo(
                 str_replace('n.', 'c.', $aVariant['VariantOnTranscript/DNA']),
-                $aTranscripts[$aVariant['transcriptid']]
+                $aTranscripts[$aVariant['id_ncbi']]
             );
             if ($aVariantInfo) {
                 list(
@@ -1092,12 +1092,12 @@ foreach ($aFiles as $sFileID) {
                     // VEP has p. notation, but without parentheses around them (see https://github.com/Ensembl/ensembl-vep/issues/498).
                     $aVariant['VariantOnTranscript/Protein'] = str_replace('p.', 'p.(', $aVariant['VariantOnTranscript/Protein'] . ')');
                 }
-            } elseif (in_array(substr($aTranscripts[$aVariant['transcriptid']]['id_ncbi'], 0, 2), array('NR', 'XR'))) {
+            } elseif (in_array(substr($aTranscripts[$aVariant['id_ncbi']]['id_ncbi'], 0, 2), array('NR', 'XR'))) {
                 // Non coding transcript, no wonder we didn't get a protein field.
                 $aVariant['VariantOnTranscript/RNA'] = 'r.(?)';
                 $aVariant['VariantOnTranscript/Protein'] = '-';
             } elseif (($aVariant['position_c_start'] < 0 && $aVariant['position_c_end'] < 0)
-                || ($aVariant['position_c_start'] > $aTranscripts[$aVariant['transcriptid']]['position_c_cds_end'] && $aVariant['position_c_end'] > $aTranscripts[$aVariant['transcriptid']]['position_c_cds_end'])
+                || ($aVariant['position_c_start'] > $aTranscripts[$aVariant['id_ncbi']]['position_c_cds_end'] && $aVariant['position_c_end'] > $aTranscripts[$aVariant['id_ncbi']]['position_c_cds_end'])
                 || ($aVariant['position_c_start_intron'] && $aVariant['position_c_end_intron'] && min(abs($aVariant['position_c_start_intron']), abs($aVariant['position_c_end_intron'])) > 5
                     && ($aVariant['position_c_start'] == $aVariant['position_c_end'] || ($aVariant['position_c_start'] == ($aVariant['position_c_end']-1) && $aVariant['position_c_start_intron'] > 0 && $aVariant['position_c_end_intron'] < 0)))) {
                 // 5'UTR, 3'UTR, fully intronic in one intron only (at least 5 bases away from exon border).
@@ -1117,7 +1117,7 @@ foreach ($aFiles as $sFileID) {
                     GROUP BY `VariantOnTranscript/RNA`, `VariantOnTranscript/Protein`
                     ORDER BY COUNT(*) DESC LIMIT 1',
                     array(
-                        $aTranscripts[$aVariant['transcriptid']]['id'],
+                        $aTranscripts[$aVariant['id_ncbi']]['id'],
                         $aVariant['position_c_start'],
                         $aVariant['position_c_start_intron'],
                         $aVariant['position_c_end'],
@@ -1132,7 +1132,7 @@ foreach ($aFiles as $sFileID) {
                     $_SETT['human_builds'][$_CONF['refseq_build']]['ncbi_sequences'][$aVariant['chromosome']] .
                     ':' . $aVariant['VariantOnGenome/DNA'] .
                     ' (' . $aVariant['chromosome'] . ':' . $aVariant['position'] . $aVariant['ref'] . '>' . $aVariant['alt'] .
-                    ' @ ' . $aVariant['transcriptid'] . ")\n");
+                    ' @ ' . $aVariant['id_ncbi'] . ")\n");
                 $nSleepTime = 2;
                 // Retry Mutalyzer call several times until successful.
                 $sJSONResponse = false;
@@ -1225,8 +1225,8 @@ foreach ($aFiles as $sFileID) {
                         $sTranscriptName = '';
 
                         // First check if we have the exact right version for it.
-                        if (isset($aMutalyzerMappings[substr(strrchr($aVariant['transcriptid'], '.'), 1)])) {
-                            $sTranscriptName = $aMutalyzerMappings[substr($aVariant['transcriptid'], strlen($aLine['transcript_noversion']))];
+                        if (isset($aMutalyzerMappings[substr(strrchr($aVariant['id_ncbi'], '.'), 1)])) {
+                            $sTranscriptName = $aMutalyzerMappings[substr($aVariant['id_ncbi'], strlen($aLine['transcript_noversion']))];
                         } else {
                             $sTranscriptName = current($aMutalyzerMappings);
                         }
@@ -1263,7 +1263,7 @@ foreach ($aFiles as $sFileID) {
                     $_SETT['human_builds'][$_CONF['refseq_build']]['ncbi_sequences'][$aVariant['chromosome']] .
                     ':' . $aVariant['VariantOnGenome/DNA'] .
                     ' (' . $aVariant['chromosome'] . ':' . $aVariant['position'] . $aVariant['ref'] . '>' . $aVariant['alt'] .
-                    ' @ ' . $aVariant['transcriptid'] . ').';
+                    ' @ ' . $aVariant['id_ncbi'] . ').';
                 $nAnnotationErrors = lovd_handleAnnotationError($aVariant, $sErrorMsg);
                 $bDropTranscriptData = $_INSTANCE_CONFIG['conversion']['annotation_error_drops_line'];
             }
@@ -1311,11 +1311,8 @@ foreach ($aFiles as $sFileID) {
             }
         }
 
-        // Replace the ncbi ID with the transcripts LOVD database ID to be used when creating the VOT record.
-        // This used to be done at the start of this else statement but since we have switched from using the headers in the file
-        // to using the column mappings (much more robust) we no longer had the ncbi ID available as it was overwritten.
-        // By moving this code down here we retain the ncbi ID for use and then overwrite at the last step.
-        $aVariant['transcriptid'] = (!isset($aTranscripts[$aVariant['transcriptid']]['id'])? '' : $aTranscripts[$aVariant['transcriptid']]['id']);
+        // Fill in the transcript's LOVD database ID to be used when creating the VOT record.
+        $aVariant['transcriptid'] = (!isset($aTranscripts[$aVariant['id_ncbi']]['id'])? '' : $aTranscripts[$aVariant['id_ncbi']]['id']);
 
 
 
@@ -1339,7 +1336,7 @@ foreach ($aFiles as $sFileID) {
         $_ADAPTER->postValueAssignmentUpdate($sKey, $aVariant, $aData);
 
         // Now, store VOT data. Because I had received test files with repeated lines, and allowing repeated lines will break import, also here we will check for the key.
-        // Also check for a set transcriptid, because it can be empty (transcript could not be created).
+        // Also check for a set transcript ID, because it can be empty (transcript could not be created).
         if (!$bDropTranscriptData && !isset($aData[$sKey][$aVariant['transcriptid']]) && $aVariant['transcriptid']) {
             $aVOT = array();
             foreach ($aVariant as $sCol => $sVal) {

--- a/src/scripts/convert_and_merge_data_files.php
+++ b/src/scripts/convert_and_merge_data_files.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2014-11-28
- * Modified    : 2025-07-16
+ * Modified    : 2025-08-13
  * For LOVD+   : 3.0-30
  *
  * Copyright   : 2004-2025 Leiden University Medical Center; http://www.LUMC.nl/
@@ -744,6 +744,24 @@ foreach ($aFiles as $sFileID) {
                 if (isset($aGenes[$aVariant['symbol']]['available_transcripts'])) {
                     $aTranscriptInfo = $aGenes[$aVariant['symbol']]['available_transcripts'];
 
+                } elseif (empty($aGenes[$aVariant['symbol']]['id_hgnc'])) {
+                    // This is a manually created gene, and we have no HGNC ID. We have no other choice than to manually create this transcript.
+                    // To make sure that we'll be able to manually create more transcripts for this gene, don't set the 'available_transcripts' key.
+                    lovd_printIfVerbose(VERBOSITY_HIGH, 'Faking transcript information for ' . $aVariant['id_ncbi'] . '...' . "\n");
+                    $aTranscriptInfo = [
+                        $aVariant['id_ncbi'] => [
+                            'name' => $aVariant['id_ncbi'] . ' (automatically created transcript)',
+                            'id_ncbi_protein' => '',
+                            'genomic_positions' => [],
+                            'transcript_positions' => [
+                                'cds_start' => null,
+                                'cds_length' => null,
+                                'length' => null,
+                            ],
+                            'select' => false,
+                        ],
+                    ];
+
                 } else {
                     lovd_printIfVerbose(VERBOSITY_HIGH, 'Loading transcript information for ' . $aGenes[$aVariant['symbol']]['id'] . '...' . "\n");
 
@@ -756,7 +774,9 @@ foreach ($aFiles as $sFileID) {
 
                     if (!$aTranscriptInfo || !empty($aTranscriptInfo['errors'])) {
                         // Something went wrong. Let the user know.
-                        lovd_printIfVerbose(VERBOSITY_MEDIUM, 'Error while retrieving transcripts for gene ' . $aGenes[$aVariant['symbol']]['id'] . ': ' . implode('; ', $aTranscriptInfo['errors']) . '.' . "\n");
+                        lovd_printIfVerbose(
+                            VERBOSITY_MEDIUM,
+                            'Error while retrieving transcripts for gene ' . $aGenes[$aVariant['symbol']]['id'] . ': ' . rtrim(implode('; ', ($aTranscriptInfo['errors'] ?? [])), '.') . '.' . "\n");
 
                     } elseif (empty($aTranscriptInfo['data'])) {
                         // No results, unfortunately.
@@ -811,13 +831,14 @@ foreach ($aFiles as $sFileID) {
 
                 if (!isset($aTranscripts[$aVariant['id_ncbi']])) {
                     // We don't have it, we can't get it... Stop looking for it, please!
+                    // We've seen this with NM_001395685.1, a suppressed record. VV dropped it.
                     $aTranscripts[$aVariant['id_ncbi']] = false;
                 }
             }
         }
         // We created the transcript if possible, but we might still not have it.
         // $aVariant['id_ncbi']                // How we received the transcript from VEP.
-        // $aTranscripts[$aVariant['id_ncbi']] // The rest of the transcript information, from the database.
+        // $aTranscripts[$aVariant['id_ncbi']] // The rest of the transcript information, from the database. Can be set to false.
 
         // Store transcript ID without version, we'll use it plenty of times.
         $aLine['transcript_noversion'] = strstr($aVariant['id_ncbi'], '.', true);
@@ -825,6 +846,7 @@ foreach ($aFiles as $sFileID) {
         if (empty($aVariant['id_ncbi']) || $_ADAPTER->ignoreTranscript($aVariant['id_ncbi']) || empty($aTranscripts[$aVariant['id_ncbi']])) {
             // When the transcript still doesn't exist, or it evaluates to false (we don't have it, we can't get it), then skip it.
             $aVariant['id_ncbi'] = '';
+
         } else { // We'll handle this transcript.
             // Handle the rest of the VOT columns.
             // First, take off the transcript name, so we can easily check for a del/ins checking for an underscore.

--- a/src/scripts/convert_and_merge_data_files.php
+++ b/src/scripts/convert_and_merge_data_files.php
@@ -414,7 +414,6 @@ foreach ($aFiles as $sFileID) {
     flush();
 
     $nLine = 0;
-    $sLastVariant = '';
     $aVOT = array();
     $aGenes = array(); // GENE => array(<gene_info_from_database>)
     $aGenesHGNC = array(); // HGNC ID => GENE (used only if we're receiving HGNC IDs).
@@ -592,12 +591,6 @@ foreach ($aFiles as $sFileID) {
                             , 3);
                 }
             }
-        }
-
-        // When seeing a new variant, reset these variables. We don't want them too big; it's useless and takes up a lot of memory.
-        if ($sLastVariant != $aVariant['chromosome'] . ':' . $aVariant['VariantOnGenome/DNA']) {
-            $sLastVariant = $aVariant['chromosome'] . ':' . $aVariant['VariantOnGenome/DNA'];
-            $aMappings = array(); // array(NM_000001.1 => 'c.123del', ...); // To prevent us from running numberConversion too many times.
         }
 
         // Now, VOT fields.
@@ -894,154 +887,60 @@ foreach ($aFiles as $sFileID) {
                     ORDER BY vog.id DESC LIMIT 1',
                     array($aTranscripts[$aVariant['id_ncbi']]['id'], $aVariant['chromosome'], $aVariant['position_g_start'], $aVariant['position_g_end'], substr(strstr($aVariant['VariantOnGenome/DNA'], ':'), 1)))->fetchAllAssoc();
 
-                // Call Mutalyzer, but first check if I did that before already.
-                if (empty($aMappings)) {
-                    $aMappings = array();
-                    lovd_printIfVerbose(VERBOSITY_FULL, 'Running position converter, DNA was: "' . $aVariant['VariantOnTranscript/DNA'] . '"' . "\n");
+                if (!$aMapping) {
+                    lovd_printIfVerbose(VERBOSITY_FULL, 'Running VariantValidator, DNA was: "' . $aVariant['VariantOnTranscript/DNA'] . '"' . "\n");
 
-                    $nSleepTime = 2;
-                    // Retry Mutalyzer call several times until successful.
-                    $sJSONResponse = false;
-                    for ($i=0; $i <= $nMutalyzerRetries; $i++) {
-                        $aMutalyzerCalls['numberConversion'] ++;
-                        $tMutalyzerStart = microtime(true);
-                        $sJSONResponse = mutalyzer_numberConversion($_CONF['refseq_build'], $_SETT['human_builds'][$_CONF['refseq_build']]['ncbi_sequences'][$aVariant['chromosome']] . ':' . $aVariant['VariantOnGenome/DNA']);
-                        $tMutalyzerCalls += (microtime(true) - $tMutalyzerStart);
-                        $nMutalyzer++;
-                        if ($sJSONResponse === false) {
-                            // The Mutalyzer call has failed.
-                            sleep($nSleepTime); // Sleep for some time.
-                            $nSleepTime = $nSleepTime * 2; // Double the amount of time that we sleep each time.
+                    $tMutalyzerStart = microtime(true);
+                    $aVV = $_VV->verifyGenomicAndPredictProtein($aVariant['VariantOnGenome/DNA'], $aVariant['id_ncbi']);
+                    $tMutalyzerCalls += (microtime(true) - $tMutalyzerStart);
+                    $aMutalyzerCalls['numberConversion']++;
+                    $nMutalyzer++;
+
+                    // Check if we got anything at all.
+                    if (!$aVV || empty($aVV['data']['DNA'])) {
+                        // VV failed completely.
+                        lovd_printIfVerbose(VERBOSITY_LOW, '>>>>> Attempted to call VV for mapping info and failed on line ' . $nLine . '.' . "\n");
+                    }
+
+                    // Check then if we received the mapping.
+                    if (isset($aVV['data']['transcript_mappings'][$aVariant['id_ncbi']])) {
+                        // VV returned the requested information; collect it.
+                        $aVV = $aVV['data']['transcript_mappings'][$aVariant['id_ncbi']];
+                        $aMapping = [
+                            'VariantOnTranscript/DNA' => $aVV['DNA'],
+                            'VariantOnTranscript/RNA' => $aVV['RNA'],
+                            'VariantOnTranscript/Protein' => $aVV['protein'],
+                        ];
+
+                    } else {
+                        // VV doesn't know how to map this variant to that transcript.
+                        // If we didn't get transcript mappings, we may be dealing with an intergenic variant.
+                        // We saw this with NC_000001.10:g.7917160_7917161insAAGGAAGGAAGGAAGGAAGGAAGG getting mapped to NM_006786.4 without a DNA field.
+                        // We used to have all kinds of fallbacks here; trying a different version of the transcript,
+                        //  or trying a different API endpoint to get something back.
+                        // The chances that this will help are very small, and they're not worth the effort.
+
+                        // If we did have DNA from VEP, we'll just accept that. Otherwise, we call it an error.
+                        $sErrorMsg = 'Can\'t map variant ' . $aVariant['VariantOnGenome/DNA'] .
+                            ' (' . $aVariant['chromosome'] . ':' . $aVariant['position'] . $aVariant['ref'] . '>' . $aVariant['alt'] . ')' .
+                            ' onto transcript ' . $aVariant['id_ncbi'] . '.';
+                        if ($aVariant['VariantOnTranscript/DNA']) {
+                            $sErrorMsg .= "\n" .
+                                'Falling back to VEP\'s DNA description!' . "\n";
+                            lovd_printIfVerbose(VERBOSITY_FULL, $sErrorMsg);
                         } else {
-                            break;
-                        }
-                    }
-
-                    if ($sJSONResponse === false) {
-                        lovd_printIfVerbose(VERBOSITY_LOW, '>>>>> Attempted to call Mutalyzer ' . $nMutalyzerRetries . ' times for numberConversion and failed on line ' . $nLine . '.' . "\n");
-                    }
-
-                    if ($sJSONResponse && $aResponse = json_decode($sJSONResponse, true)) {
-                        // Before we had to go two layers deep; through the result, then read out the string.
-                        // But now apparently this service just returns the string with quotes (the latter are removed by json_decode()).
-                        foreach ($aResponse as $sResponse) {
-                            list($sRef, $sDNA) = explode(':', $sResponse, 2);
-                            $aMappings[$sRef] = $sDNA;
+                            $nAnnotationErrors = lovd_handleAnnotationError($aVariant, $sErrorMsg);
+                            $bDropTranscriptData = $_INSTANCE_CONFIG['conversion']['annotation_error_drops_line'];
                         }
                     }
                 }
 
-                // Find mapping of variant on the currently handled transcript.
-                if (isset($aMappings[$aTranscripts[$aVariant['id_ncbi']]['id_ncbi']])) {
-                    // Successfully mapped on the transcript version that we have in the database.
-                    $aVariant['VariantOnTranscript/DNA'] = $aMappings[$aTranscripts[$aVariant['id_ncbi']]['id_ncbi']];
-                } elseif (isset($aMappings[$aVariant['id_ncbi']])) {
-                    // Successfully mapped on the transcript version received by VEP.
-                    $aVariant['VariantOnTranscript/DNA'] = $aMappings[$aVariant['id_ncbi']];
-                } else {
-                    // Somehow, we can't find the transcript in the mapping info.
-                    // This can only happen either when the NC has a different transcript than the one we have in the
-                    //  position converter database,
-                    //  or when VEP says the variant maps, but Mutalyzer disagrees (variant may be outside of gene).
-                    // Try finding the transcript for other versions. Just take first one you find.
-                    $aAlternativeVersions = array();
-                    foreach ($aMappings as $sRef => $sDNA) {
-                        if (strpos($sRef, $aLine['transcript_noversion']) === 0) {
-                            $aAlternativeVersions[] = $sRef;
-                        }
-                    }
-                    if ($aAlternativeVersions) {
-                        lovd_printIfVerbose(VERBOSITY_FULL, 'Found alternative by searching: ' . $aVariant['id_ncbi'] . ' [' . implode(', ', $aAlternativeVersions) . ']' . "\n");
-                        $aVariant['VariantOnTranscript/DNA'] = $aMappings[$aAlternativeVersions[0]];
-                    } else {
-                        // This happens when VEP says we can map on a known transcript, but doesn't provide us a valid mapping,
-                        // *and* Mutalyzer at the same time doesn't seem to be able to map to this transcript at all.
-                        // This happens sometimes with variants outside of genes, that VEP apparently considers close enough,
-                        //  or differences between the position converter database versus de NC-based database.
-
-                        // Still no mapping. If we did have DNA from VEP, we'll just accept that. Otherwise, we call it an error.
-                        $sErrorMsg = 'Can\'t map variant ' .
-                            $_SETT['human_builds'][$_CONF['refseq_build']]['ncbi_sequences'][$aVariant['chromosome']] .
-                            ':' . $aVariant['VariantOnGenome/DNA'] .
-                            ' (' . $aVariant['chromosome'] . ':' . $aVariant['position'] . $aVariant['ref'] . '>' . $aVariant['alt'] . ') ' .
-                            'onto transcript ' . $aLine['transcript_noversion'] . '*.';
-                        if ($aVariant['VariantOnTranscript/DNA']) {
-                            $sErrorMsg .= "\n" .
-                                          'Falling back to VEP\'s DNA description!' . "\n";
-                            lovd_printIfVerbose(VERBOSITY_FULL, $sErrorMsg);
-                        } else {
-                            // We have one more solution - call the name checker and try to find the mapping there.
-                            // This is a very slow procedure and will hopefully not be used often, but due to recent
-                            //  developments, Mutalyzer's position converter database diverged from the maintained database.
-
-                            // FIXME: This is a lot of repeated code again. Better clean it up.
-                            lovd_printIfVerbose(VERBOSITY_FULL, 'Mutalyzer\'s position converter doesn\'t know transcript, falling back to the name checker instead!' . "\n");
-                            $nSleepTime = 2;
-                            // Retry Mutalyzer call several times until successful.
-                            $sJSONResponse = false;
-                            for ($i=0; $i <= $nMutalyzerRetries; $i++) {
-                                $aMutalyzerCalls['runMutalyzer'] ++;
-                                $tMutalyzerStart = microtime(true);
-                                $sJSONResponse = mutalyzer_runMutalyzer(rawurlencode($_SETT['human_builds'][$_CONF['refseq_build']]['ncbi_sequences'][$aVariant['chromosome']] . ':' . $aVariant['VariantOnGenome/DNA']));
-                                $tMutalyzerCalls += (microtime(true) - $tMutalyzerStart);
-                                $nMutalyzer++;
-                                if ($sJSONResponse === false) {
-                                    // The Mutalyzer call has failed.
-                                    sleep($nSleepTime); // Sleep for some time.
-                                    $nSleepTime = $nSleepTime * 2; // Double the amount of time that we sleep each time.
-                                } else {
-                                    break;
-                                }
-                            }
-                            if ($sJSONResponse === false) {
-                                lovd_printIfVerbose(VERBOSITY_LOW, '>>>>> Attempted to call Mutalyzer ' . $nMutalyzerRetries . ' times to runMutalyzer and failed on line ' . $nLine . '.' . "\n");
-                            }
-
-                            if ($sJSONResponse && $aResponse = json_decode($sJSONResponse, true)) {
-                                // Find DNA mapping in mutalyzer output.
-                                if (!empty($aResponse['legend']) && !empty($aResponse['transcriptDescriptions'])) {
-                                    // Store the *versions* of the wanted transcript. Only versions, so it sorts nicely.
-                                    // Store the transcript names (v-numbers) that we find.
-                                    $aMutalyzerMappings = array(); // array("1" => PRAMEF22_v001).
-
-                                    // Loop over legend records to find transcript name (v-number).
-                                    // Mutalyzer can provide both the wanted transcript and other versions here,
-                                    //  sometimes both at the same time, e.g. with NC_000001.10:g.13183634G>A.
-                                    foreach ($aResponse['legend'] as $aRecord) {
-                                        if (isset($aRecord['id']) && strpos($aRecord['id'], $aLine['transcript_noversion']) === 0) {
-                                            $aMutalyzerMappings[substr($aRecord['id'], strlen($aLine['transcript_noversion']))] = $aRecord['name'];
-                                        }
-                                    }
-                                    // Sort the found transcripts on their version, descending.
-                                    krsort($aMutalyzerMappings);
-                                    $sTranscriptName = '';
-                                    // First check if we have the exact right version for it.
-                                    if (isset($aMutalyzerMappings[substr(strrchr($aVariant['id_ncbi'], '.'), 1)])) {
-                                        $sTranscriptName = $aMutalyzerMappings[substr($aVariant['id_ncbi'], strlen($aLine['transcript_noversion']))];
-                                    } else {
-                                        $sTranscriptName = current($aMutalyzerMappings);
-                                    }
-
-                                    if ($sTranscriptName) {
-                                        // Select DNA mapping based on the found v-number.
-                                        foreach ($aResponse['transcriptDescriptions'] as $sMutalyzerMapping) {
-                                            if (strpos($sMutalyzerMapping, $_SETT['human_builds'][$_CONF['refseq_build']]['ncbi_sequences'][$aVariant['chromosome']] . '(' . $sTranscriptName . '):') === 0) {
-                                                // Match on v-number in given mappings.
-                                                $aVariant['VariantOnTranscript/DNA'] = substr(strchr($sMutalyzerMapping, ':'), 1);
-                                                break;
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-
-                            if (!$aVariant['VariantOnTranscript/DNA']) {
-                                // This fallback also failed :(
-                                $nAnnotationErrors = lovd_handleAnnotationError($aVariant, $sErrorMsg);
-                                $bDropTranscriptData = $_INSTANCE_CONFIG['conversion']['annotation_error_drops_line'];
-                            }
-                        }
-                    }
+                if ($aMapping) {
+                    // Copy everything over to $aVariant.
+                    $aVariant = array_merge(
+                        $aVariant,
+                        $aMapping
+                    );
                 }
             }
 

--- a/src/scripts/convert_and_merge_data_files.php
+++ b/src/scripts/convert_and_merge_data_files.php
@@ -616,7 +616,18 @@ foreach ($aFiles as $sFileID) {
         if (!isset($aGenes[$aVariant['symbol']])) {
             if (isset($aGeneAliases[$aVariant['symbol']])) {
                 $aVariant['symbol'] = $aGeneAliases[$aVariant['symbol']];
-            } elseif (!empty($aVariant['id_hgnc']) && isset($aGenesHGNC[$aVariant['id_hgnc']])) {
+            } elseif (empty($aVariant['id_hgnc'])) {
+                // Use the HGVS syntax checker, and store the alias.
+                $HGVS = HGVS_Gene::check($aVariant['symbol']);
+                $nHGNC = ($HGVS->getInfo()['data']['hgnc_id'] ?? 0);
+                $sSymbol = $_DB->q('SELECT id FROM ' . TABLE_GENES . ' WHERE id_hgnc = ?', array($nHGNC))->fetchColumn();
+                if ($sSymbol) {
+                    // Store for the rest of the variants in this file.
+                    $aGeneAliases[$aVariant['symbol']] = $sSymbol;
+                    $aVariant['symbol'] = $sSymbol;
+                    lovd_printIfVerbose(VERBOSITY_MEDIUM, 'Gene stored as \'' . $aVariant['symbol'] . '\' is given to us as \'' . $aVariant['symbol_vep'] . '\'; using our gene symbol.' . "\n");
+                }
+            } elseif (isset($aGenesHGNC[$aVariant['id_hgnc']])) {
                 // VEP has a newer gene symbol. Better warn about this.
                 $aVariant['symbol'] = $aGenesHGNC[$aVariant['id_hgnc']];
                 lovd_printIfVerbose(VERBOSITY_MEDIUM, 'Gene stored as \'' . $aVariant['symbol'] . '\' is given to us as \'' . $aVariant['symbol_vep'] . '\'; using our gene symbol.' . "\n");

--- a/src/scripts/convert_and_merge_data_files.php
+++ b/src/scripts/convert_and_merge_data_files.php
@@ -972,218 +972,53 @@ foreach ($aFiles as $sFileID) {
                     ($aVariant['position_c_start_intron']?
                         abs($aVariant['position_c_start_intron']) : abs($aVariant['position_c_end_intron'])));
 
-            // VariantOnTranscript/RNA && VariantOnTranscript/Protein.
-            // Try to do as much as possible by ourselves.
-            $aVariant['VariantOnTranscript/RNA'] = '';
-            // Convert VEP's (p.%3D) to (p.=). They have to encode = to prevent parser errors.
-            $aVariant['VariantOnTranscript/Protein'] = urldecode($aVariant['VariantOnTranscript/Protein']);
-            if ($aVariant['VariantOnTranscript/Protein']) {
-                // VEP came up with something...
-                $aVariant['VariantOnTranscript/RNA'] = 'r.(?)';
-                if (strpos($aVariant['VariantOnTranscript/Protein'], ':') !== false) {
-                    $aVariant['VariantOnTranscript/Protein'] = substr($aVariant['VariantOnTranscript/Protein'], strpos($aVariant['VariantOnTranscript/Protein'], ':')+1); // NP_000000.1:p.Met1? -> p.Met1?
-                }
-                if ($aVariant['VariantOnTranscript/Protein'] == $aVariant['VariantOnTranscript/DNA/VEP'] . '(p.=)'
-                    || preg_match('/^p\.([A-Z][a-z]{2})+([0-9]+)=$/', $aVariant['VariantOnTranscript/Protein'])) {
-                    // But sometimes VEP messes up; DNA: c.4482G>A; Prot: c.4482G>A(p.=) or
-                    //  Prot: p.ValSerThrAspHisAlaThrSerLeuProValThrIleProSerAlaAla1225=
-                    // 2019-06-19; May have been fixed, not observed anymore.
-                    $aVariant['VariantOnTranscript/Protein'] = 'p.(=)';
-                } elseif (substr($aVariant['VariantOnTranscript/Protein'], 0, 2) == 'p.'
-                    && (substr($aVariant['VariantOnTranscript/Protein'], 2, 1) != '('
-                        || substr($aVariant['VariantOnTranscript/Protein'], -1) != ')')) {
-                    // VEP has p. notation, but without parentheses around them (see https://github.com/Ensembl/ensembl-vep/issues/498).
-                    $aVariant['VariantOnTranscript/Protein'] = str_replace('p.', 'p.(', $aVariant['VariantOnTranscript/Protein'] . ')');
-                }
-            } elseif (in_array(substr($aTranscripts[$aVariant['id_ncbi']]['id_ncbi'], 0, 2), array('NR', 'XR'))) {
-                // Non coding transcript, no wonder we didn't get a protein field.
-                $aVariant['VariantOnTranscript/RNA'] = 'r.(?)';
-                $aVariant['VariantOnTranscript/Protein'] = '-';
-            } elseif (($aVariant['position_c_start'] < 0 && $aVariant['position_c_end'] < 0)
-                || ($aVariant['position_c_start'] > $aTranscripts[$aVariant['id_ncbi']]['position_c_cds_end'] && $aVariant['position_c_end'] > $aTranscripts[$aVariant['id_ncbi']]['position_c_cds_end'])
-                || ($aVariant['position_c_start_intron'] && $aVariant['position_c_end_intron'] && min(abs($aVariant['position_c_start_intron']), abs($aVariant['position_c_end_intron'])) > 5
-                    && ($aVariant['position_c_start'] == $aVariant['position_c_end'] || ($aVariant['position_c_start'] == ($aVariant['position_c_end']-1) && $aVariant['position_c_start_intron'] > 0 && $aVariant['position_c_end_intron'] < 0)))) {
-                // 5'UTR, 3'UTR, fully intronic in one intron only (at least 5 bases away from exon border).
-                $aVariant['VariantOnTranscript/RNA'] = 'r.(=)';
-                $aVariant['VariantOnTranscript/Protein'] = 'p.(=)';
-            } elseif (($aVariant['position_c_start_intron'] && (!$aVariant['position_c_end_intron'] || abs($aVariant['position_c_start_intron']) <= 5))
-                || ($aVariant['position_c_end_intron'] && (!$aVariant['position_c_start_intron'] || abs($aVariant['position_c_end_intron']) <= 5))) {
-                // Partially intronic, or variants spanning multiple introns, or within first/last 5 bases of an intron.
-                $aVariant['VariantOnTranscript/RNA'] = 'r.spl?';
-                $aVariant['VariantOnTranscript/Protein'] = 'p.?';
-            } elseif (!$bDropTranscriptData && $aVariant['VariantOnTranscript/DNA']
-                // Try to prevent running Mutalyzer one last time. Fetch protein description from the database.
-                && ($aVOTFromDB = $_DB->q('
-                    SELECT `VariantOnTranscript/RNA`, `VariantOnTranscript/Protein`, COUNT(*)
-                    FROM ' . TABLE_VARIANTS_ON_TRANSCRIPTS . '
-                    WHERE transcriptid = ? AND position_c_start = ? AND position_c_start_intron = ? AND position_c_end = ? AND position_c_end_intron = ? AND `VariantOnTranscript/DNA` = ?
-                    GROUP BY `VariantOnTranscript/RNA`, `VariantOnTranscript/Protein`
-                    ORDER BY COUNT(*) DESC LIMIT 1',
-                    array(
-                        $aTranscripts[$aVariant['id_ncbi']]['id'],
-                        $aVariant['position_c_start'],
-                        $aVariant['position_c_start_intron'],
-                        $aVariant['position_c_end'],
-                        $aVariant['position_c_end_intron'],
-                        $aVariant['VariantOnTranscript/DNA']))->fetchRow()) && $aVOTFromDB) {
-                // Variant has been found in the database. Use the most common RNA and Protein description we found.
-                $aVariant['VariantOnTranscript/RNA'] = $aVOTFromDB[0];
-                $aVariant['VariantOnTranscript/Protein'] = $aVOTFromDB[1];
-            } elseif (!$bDropTranscriptData && $aVariant['VariantOnTranscript/DNA']) {
-                // OK, too bad, we need to run Mutalyzer anyway (only if we're using this VOT line).
-                lovd_printIfVerbose(VERBOSITY_MEDIUM, 'Running mutalyzer to predict protein change for ' .
-                    $_SETT['human_builds'][$_CONF['refseq_build']]['ncbi_sequences'][$aVariant['chromosome']] .
-                    ':' . $aVariant['VariantOnGenome/DNA'] .
-                    ' (' . $aVariant['chromosome'] . ':' . $aVariant['position'] . $aVariant['ref'] . '>' . $aVariant['alt'] .
-                    ' @ ' . $aVariant['id_ncbi'] . ")\n");
-                $nSleepTime = 2;
-                // Retry Mutalyzer call several times until successful.
-                $sJSONResponse = false;
-                for ($i=0; $i <= $nMutalyzerRetries; $i++) {
-                    $aMutalyzerCalls['runMutalyzer'] ++;
-                    $tMutalyzerStart = microtime(true);
-                    $sJSONResponse = mutalyzer_runMutalyzer(rawurlencode($_SETT['human_builds'][$_CONF['refseq_build']]['ncbi_sequences'][$aVariant['chromosome']] . ':' . $aVariant['VariantOnGenome/DNA']));
-                    $tMutalyzerCalls += (microtime(true) - $tMutalyzerStart);
-                    $nMutalyzer++;
-                    if ($sJSONResponse === false) {
-                        // The Mutalyzer call has failed.
-                        sleep($nSleepTime); // Sleep for some time.
-                        $nSleepTime = $nSleepTime * 2; // Double the amount of time that we sleep each time.
-                    } else {
-                        break;
+            // Fill in VariantOnTranscript/RNA && VariantOnTranscript/Protein. Try to do as much as possible by
+            //  ourselves. However, we may already have this, if we queried the database or asked VV for a mapping.
+            // Only do this, when we don't have the RNA field yet.
+            if (empty($aVariant['VariantOnTranscript/RNA'])) {
+                // We didn't query the database, and we didn't ask VV for a mapping. So we only have VEPs DNA and protein fields.
+                if (!empty($aVariant['VariantOnTranscript/Protein'])) {
+                    // VEP came up with something...
+                    if (strpos($aVariant['VariantOnTranscript/Protein'], ':') !== false) {
+                        $aVariant['VariantOnTranscript/Protein'] = substr(strstr($aVariant['VariantOnTranscript/Protein'], ':'), 1); // NP_000000.1:p.Met1? -> p.Met1?
+                    }
+                    // Convert VEP's (p.%3D) to (p.=). They have to encode = to prevent parser errors.
+                    $aVariant['VariantOnTranscript/Protein'] = urldecode($aVariant['VariantOnTranscript/Protein']);
+                    if ($aVariant['VariantOnTranscript/Protein'] == $aVariant['VariantOnTranscript/DNA/VEP'] . '(p.=)'
+                        || preg_match('/^p\.([A-Z][a-z]{2})+([0-9]+)=$/', $aVariant['VariantOnTranscript/Protein'])) {
+                        // But sometimes VEP messes up; DNA: c.4482G>A; Prot: c.4482G>A(p.=) or
+                        //  Prot: p.ValSerThrAspHisAlaThrSerLeuProValThrIleProSerAlaAla1225=
+                        // 2019-06-19; May have been fixed, not observed anymore.
+                        $aVariant['VariantOnTranscript/Protein'] = 'p.(=)';
+                    } elseif (substr($aVariant['VariantOnTranscript/Protein'], 0, 2) == 'p.'
+                        && (substr($aVariant['VariantOnTranscript/Protein'], 2, 1) != '('
+                            || substr($aVariant['VariantOnTranscript/Protein'], -1) != ')')) {
+                        // VEP has p. notation, but without parentheses around them (see https://github.com/Ensembl/ensembl-vep/issues/498).
+                        $aVariant['VariantOnTranscript/Protein'] = str_replace('p.', 'p.(', $aVariant['VariantOnTranscript/Protein'] . ')');
                     }
                 }
-                if ($sJSONResponse === false) {
-                    lovd_printIfVerbose(VERBOSITY_LOW, '>>>>> Attempted to call Mutalyzer ' . $nMutalyzerRetries . ' times to runMutalyzer and failed on line ' . $nLine . '.' . "\n");
-                }
 
-                if ($sJSONResponse && $aResponse = json_decode($sJSONResponse, true)) {
-                    // Predict RNA && Protein change.
-                    // 'Intelligent' error handling.
-                    // FIXME: Implement lovd_getRNAProteinPrediction() here.
-                    // LOVD3's version is CURL-ready and uses JSON.
-                    foreach ($aResponse['messages'] as $aError) {
-                        // Pass other errors on to the users?
-                        // FIXME: This is implemented as well in inc-lib-variants.php (LOVD3.0-15).
-                        //  When we update LOVD+ to LOVD 3.0-15, use this lib so we don't duplicate code...
-                        if (isset($aError['errorcode']) && $aError['errorcode'] == 'ERANGE') {
-                            // Ignore 'ERANGE' as an actual error, because we can always interpret this as p.(=), p.? or p.0.
-                            $aVariantRange = explode('_', $aVariant['VariantOnTranscript/DNA']);
-                            // Check what the variant looks like and act accordingly.
-                            if (count($aVariantRange) === 2 && preg_match('/-\d+/', $aVariantRange[0]) && preg_match('/-\d+/', $aVariantRange[1])) {
-                                // Variant has 2 positions. Variant has both the start and end positions upstream of the transcript, we can assume that the product will not be affected.
-                                $sPredictR = 'r.(=)';
-                                $sPredictP = 'p.(=)';
-                            } elseif (count($aVariantRange) === 2 && preg_match('/-\d+/', $aVariantRange[0]) && preg_match('/\*\d+/', $aVariantRange[1])) {
-                                // Variant has 2 positions. Variant has an upstream start position and a downstream end position, we can assume that the product will not be expressed.
-                                $sPredictR = 'r.0?';
-                                $sPredictP = 'p.0?';
-                            } elseif (count($aVariantRange) == 2 && preg_match('/\*\d+/', $aVariantRange[0]) && preg_match('/\*\d+/', $aVariantRange[1])) {
-                                // Variant has 2 positions. Variant has both the start and end positions downstream of the transcript, we can assume that the product will not be affected.
-                                $sPredictR = 'r.(=)';
-                                $sPredictP = 'p.(=)';
-                            } elseif (count($aVariantRange) == 1 && preg_match('/-\d+/', $aVariantRange[0]) || preg_match('/\*\d+/', $aVariantRange[0])) {
-                                // Variant has 1 position and is either upstream or downstream from the transcript, we can assume that the product will not be affected.
-                                $sPredictR = 'r.(=)';
-                                $sPredictP = 'p.(=)';
-                            } else {
-                                // One of the positions of the variant falls within the transcript, so we can not make any assumptions based on that.
-                                $sPredictR = 'r.?';
-                                $sPredictP = 'p.?';
-                            }
-                            // Fill in our assumption to forge that this information came from Mutalyzer.
-                            $aVariant['VariantOnTranscript/RNA'] = $sPredictR;
-                            $aVariant['VariantOnTranscript/Protein'] = $sPredictP;
-                            break;
-                        } elseif (isset($aError['errorcode']) && $aError['errorcode'] == 'WSPLICE') {
-                            $aVariant['VariantOnTranscript/RNA'] = 'r.spl?';
-                            $aVariant['VariantOnTranscript/Protein'] = 'p.?';
-                            break;
-                        } elseif (isset($aError['errorcode']) && $aError['errorcode'] == 'EREF') {
-                            // This can happen, because we have UDs from hg38, but the alignment and variant calling is done on hg19... :(  Sequence can be different.
-                            $aVariant['VariantOnTranscript/RNA'] = 'r.(?)';
-                            $aVariant['VariantOnTranscript/Protein'] = 'p.?';
-                            lovd_printIfVerbose(VERBOSITY_MEDIUM, 'Mutalyzer returned EREF error, hg19/hg38 error?' . "\n");
-                            // We don't break here, because if there is also a WSPLICE we rather go with that one.
-                        }
-                    }
+                // We used to have very complicated code here, but we can just rely on the VV library.
+                // We have the same functionality there, so why reinvent the wheel? This function is better.
+                $aMapping = [
+                    'DNA' => $aVariant['VariantOnTranscript/DNA'],
+                    'protein' => ($aVariant['VariantOnTranscript/Protein'] ?? ''),
+                ];
+                $_VV->getRNAProteinPrediction($aMapping, $aVariant['id_ncbi']);
 
-                    // Find protein prediction in mutalyzer output.
-                    if (!$aVariant['VariantOnTranscript/Protein'] && !empty($aResponse['legend']) && !empty($aResponse['proteinDescriptions'])) {
-                        // Store the *versions* of the wanted transcript. Only versions, so it sorts nicely.
-                        // Store the transcript names (v-numbers) that we find.
-                        $aMutalyzerMappings = array(); // array("1" => PRAMEF22_v001).
-
-                        // Loop over legend records to find transcript name (v-number).
-                        // Mutalyzer can provide both the wanted transcript and other versions here,
-                        //  sometimes both at the same time, e.g. with NC_000001.10:g.13183634G>A.
-                        foreach ($aResponse['legend'] as $aRecord) {
-                            if (isset($aRecord['id']) && strpos($aRecord['id'], $aLine['transcript_noversion']) === 0
-                                && substr($aRecord['name'], -4, 1) == 'v') {
-                                $aMutalyzerMappings[substr($aRecord['id'], strlen($aLine['transcript_noversion']))] = $aRecord['name'];
-                            }
-                        }
-                        // Sort the found transcripts on their version, descending.
-                        krsort($aMutalyzerMappings);
-                        $sTranscriptName = '';
-
-                        // First check if we have the exact right version for it.
-                        if (isset($aMutalyzerMappings[substr(strrchr($aVariant['id_ncbi'], '.'), 1)])) {
-                            $sTranscriptName = $aMutalyzerMappings[substr($aVariant['id_ncbi'], strlen($aLine['transcript_noversion']))];
-                        } else {
-                            $sTranscriptName = current($aMutalyzerMappings);
-                        }
-
-                        if ($sTranscriptName) {
-                            // Generate protein isoform name (i-number) from transcript name (v-number).
-                            $sProteinName = str_replace('_v', '_i', $sTranscriptName);
-
-                            // Select protein description based on protein isoform (i-number).
-                            foreach ($aResponse['proteinDescriptions'] as $sMutalyzerMapping) {
-                                if (strpos($sMutalyzerMapping, $_SETT['human_builds'][$_CONF['refseq_build']]['ncbi_sequences'][$aVariant['chromosome']] . '(' . $sProteinName . '):') === 0) {
-                                    // Match on i-number in given mappings.
-                                    $aVariant['VariantOnTranscript/Protein'] = substr(strchr($sMutalyzerMapping, ':'), 1);
-                                    if ($aVariant['VariantOnTranscript/Protein'] == 'p.?') {
-                                        $aVariant['VariantOnTranscript/RNA'] = 'r.?';
-                                    } elseif ($aVariant['VariantOnTranscript/Protein'] == 'p.(=)') {
-                                        // FIXME: Not correct in case of substitutions e.g. in the third position of the codon, not leading to a protein change.
-                                        $aVariant['VariantOnTranscript/RNA'] = 'r.(=)';
-                                    } else {
-                                        // RNA will default to r.(?).
-                                        $aVariant['VariantOnTranscript/RNA'] = 'r.(?)';
-                                    }
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
-                // Any errors related to the prediction of Exon, RNA or Protein are silently ignored.
+                // And now copy it back.
+                $aVariant['VariantOnTranscript/RNA'] = $aMapping['RNA'];
+                $aVariant['VariantOnTranscript/Protein'] = $aMapping['protein'];
             }
 
             if (!$bDropTranscriptData && $aVariant['VariantOnTranscript/DNA'] && !$aVariant['VariantOnTranscript/RNA']) {
-                $sErrorMsg = 'Missing VariantOnTranscript/RNA for ' .
-                    $_SETT['human_builds'][$_CONF['refseq_build']]['ncbi_sequences'][$aVariant['chromosome']] .
-                    ':' . $aVariant['VariantOnGenome/DNA'] .
+                $sErrorMsg = 'Missing VariantOnTranscript/RNA for ' . $aVariant['VariantOnGenome/DNA'] .
                     ' (' . $aVariant['chromosome'] . ':' . $aVariant['position'] . $aVariant['ref'] . '>' . $aVariant['alt'] .
                     ' @ ' . $aVariant['id_ncbi'] . ').';
                 $nAnnotationErrors = lovd_handleAnnotationError($aVariant, $sErrorMsg);
                 $bDropTranscriptData = $_INSTANCE_CONFIG['conversion']['annotation_error_drops_line'];
             }
 
-            if (!$bDropTranscriptData) {
-                // OK, so we're not dropping the line. But we may not have DNA, RNA or Protein.
-                // So we'll need to make sure LOVD+ can actually import the data, then!
-                if (!$aVariant['VariantOnTranscript/DNA']) {
-                    $aVariant['VariantOnTranscript/DNA'] = 'c.?';
-                }
-                if (!$aVariant['VariantOnTranscript/RNA']) {
-                    $aVariant['VariantOnTranscript/RNA'] = 'r.(?)';
-                }
-                if (!$aVariant['VariantOnTranscript/Protein']) {
-                    $aVariant['VariantOnTranscript/Protein'] = 'p.(?)';
-                }
-            }
         }
 
         // DNA fields and protein field can be super long with long inserts.


### PR DESCRIPTION
### Use VariantValidator
- Add the HGVS syntax checker as a submodule. The HGVS syntax checker also includes gene recognition, and this repo includes the VV library, as an alternative to Mutalyzer v2.
- Replace `lovd_getVariantDescription()` with the HGVS library.
- For unknown genes and without an HGNC ID, use the HGVS library.
- Update the Leiden adapter; the HGNC ID field has been renamed. Also, update comments in the adapters.
- Untangle and separate the transcriptid and id_ncbi fields. The `transcriptid` field was also used for the NCBI ID, and this caused a lot of confusion.
- Remember a gene's HGNC ID as well, and optimize gene creation.
- Replace Mutalyzer's `getTranscriptsAndInfo` by a VV method. This greatly reduces the amount of code needed. However, we should still update the downstream code to handle the new data structure. Note that the old code used to compare transcripts while IGNORING the version numbers. Mutalyzer v2 has issues, of course, keeping the annotation up to date. However, they want newer transcripts and we're now using VV. So, we'll match transcripts including their version numbers now.
- Update the code that creates the transcripts in the DB.
- Allow creating fake transcripts directly during conversion. This makes sure that we don't lose the annotation.
- Reduce the number of API calls; we can generate a lot ourselves. We can choose `c.?` for UTR and intergenic variants, and we can auto-predict the RNA and protein fields for those and intronic variants.
- Before calling VV, double-check the database for mapping info.
- Replace Mutalyzer's API calls with VV. Removed the position converter and the name checker with VV's API. That is much faster, also because we can select a specific transcript to map on. That also allows us to remove some weird caching mechanism from the scripts.
- Default to `c.?` if all else fails, and small other improvements. Make sure we handle missing fields better, and no longer mess with the DNA description to fake the description to get better position fields. We no longer use Mutalyzer, so we won't have this problem.
- Replace the code that generates RNA and protein descriptions. Just use existing code from the VV library, so we won't have to reinvent the wheel. This also removes yet another interaction with Mutalyzer. VV combines the features that Mutalyzer 2 called the "position converter" and the "name checker" in one call.
- Clean up and remove the last Mutalyzer mentions with VV.
- Update to newer HGVS; `ins(6)` is no longer a valid description.
- Final cleanups.
- Update the LOVD HGVS library to v0.5.2.
- Document the use of the HGVS library and its gene cache.
- Update the manual stats on the docs page.